### PR TITLE
Resolved memory/handle leak by removing cyclic reference between Requ…

### DIFF
--- a/source/corvusoft/restbed/http.cpp
+++ b/source/corvusoft/restbed/http.cpp
@@ -89,6 +89,7 @@ namespace restbed
         if ( request not_eq nullptr and request->m_pimpl->m_socket not_eq nullptr )
         {
             request->m_pimpl->m_socket->close( );
+            request->m_pimpl->m_response = nullptr;
         }
     }
     


### PR DESCRIPTION
…est/Response upon close

The mutual reference between Request & Response was preventing the objects from being destroyed and was causing both a memory and handle leak.  This patch un-sets the Response reference in `Http::close` and the clean-up now occurs as expected.