### PR TITLE
Merging fix for location searched for OpenSSL for OSX

### DIFF
--- a/cmake/modules/Findopenssl.cmake
+++ b/cmake/modules/Findopenssl.cmake
@@ -1,13 +1,13 @@
 # Copyright 2013-2016, Corvusoft Ltd, All Rights Reserved.
 
-find_library( ssl_LIBRARY ssl ssleay32 HINTS "${CMAKE_SOURCE_DIR}/dependency/openssl/out32dll" "${CMAKE_SOURCE_DIR}/dependency/openssl" "/usr/lib" "/usr/local/lib" "/opt/local/lib" )
-find_library( crypto_LIBRARY crypto libeay32 HINTS "${CMAKE_SOURCE_DIR}/dependency/openssl/out32dll" "${CMAKE_SOURCE_DIR}/dependency/openssl" "/usr/lib" "/usr/local/lib" "/opt/local/lib" )
-find_path( ssl_INCLUDE openssl/ssl.h HINTS "${CMAKE_SOURCE_DIR}/dependency/openssl/inc32" "${CMAKE_SOURCE_DIR}/dependency/openssl/include" "/usr/include" "/usr/local/include" "/opt/local/include" )
+find_library( ssl_LIBRARY ssl ssleay32 HINTS "${CMAKE_SOURCE_DIR}/dependency/openssl/out32dll" "${CMAKE_SOURCE_DIR}/dependency/openssl" "/usr/local/opt/openssl/lib" "/usr/lib" "/usr/local/lib" "/opt/local/lib" )
+find_library( crypto_LIBRARY crypto libeay32 HINTS "${CMAKE_SOURCE_DIR}/dependency/openssl/out32dll" "${CMAKE_SOURCE_DIR}/dependency/openssl" "/usr/local/opt/openssl/lib" "/usr/lib" "/usr/local/lib" "/opt/local/lib" )
+find_path( ssl_INCLUDE openssl/ssl.h HINTS "${CMAKE_SOURCE_DIR}/dependency/openssl/inc32" "${CMAKE_SOURCE_DIR}/dependency/openssl/include" "/usr/local/opt/openssl/lib" "/usr/include" "/usr/local/include" "/opt/local/include" )
 
 if ( ssl_INCLUDE AND ssl_LIBRARY AND crypto_LIBRARY )
     set( OPENSSL_FOUND TRUE )
     add_definitions( -DBUILD_SSL=TRUE )
-    
+
     if ( APPLE AND BUILD_SSL )
         set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-declarations" )
     endif( )


### PR DESCRIPTION
OSX uses a proprietary SSL/TLS library instead of OpenSSL. Since Restbed uses OpenSSL, cmake has to be pointed to OpenSSL version installed via 'brew install openssl'.