### PR TITLE
Fix #86: ECDHE with ASIO (w/ pull request #117)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ option( BUILD_SHARED   "Build shared library."              OFF )
 option( BUILD_EXAMPLES "Build examples applications."       OFF )
 option( BUILD_TESTS    "Build all available test suites."   OFF )
 option( BUILD_SSL      "Build secure socket layer support."  ON )
+option( ECDHE_SUPPORT  "Support for ECDHE-based cipher suites" OFF )
 
 #
 # Configuration
@@ -31,6 +32,10 @@ if ( BUILD_SSL )
     find_package( openssl REQUIRED )
     include_directories( SYSTEM ${ssl_INCLUDE} )
 endif ( )
+
+if ( ECDHE_SUPPORT )
+    add_definitions(-DECDHE_SUPPORT)
+endif ( ECDHE_SUPPORT )
 
 #
 # Build

--- a/example/https_service/source/example.cpp
+++ b/example/https_service/source/example.cpp
@@ -37,7 +37,11 @@ int main( const int, const char** )
     ssl_settings->set_http_disabled( true );
     ssl_settings->set_private_key( Uri( "file:///tmp/server.key" ) );
     ssl_settings->set_certificate( Uri( "file:///tmp/server.crt" ) );
+#ifndef ECDHE_SUPPORT
     ssl_settings->set_temporary_diffie_hellman( Uri( "file:///tmp/dh768.pem" ) );
+#else
+    ssl_settings->set_temporary_ecc_diffie_hellman(true);
+#endif
     
     auto settings = make_shared< Settings >( );
     settings->set_ssl_settings( ssl_settings );

--- a/source/corvusoft/restbed/detail/service_impl.cpp
+++ b/source/corvusoft/restbed/detail/service_impl.cpp
@@ -245,26 +245,9 @@ namespace restbed
                 m_ssl_context->set_options( options );
                 
 #ifdef ECDHE_SUPPORT
-                if ( m_ssl_settings->has_enabled_single_ecc_diffie_hellman_use() )
+                if ( m_ssl_settings->has_enabled_ecc_diffie_hellman_use() )
                 {
-                    int nid = OBJ_sn2nid("prime256v1"); // FIXME: Only supports secp256r1; make more generic
-                    if( nid == 0 )
-                    {
-                        log( Logger::ERROR, "failed to find nid for ECDHE curve prime256v1");
-                    }
-                    else
-                    {
-                        EC_KEY *ecdh = EC_KEY_new_by_curve_name(nid);
-                        if(!ecdh)
-                        {
-                            log( Logger::ERROR, "failed to allocated new ECDH key");
-                        }
-                        else
-                        {
-                            SSL_CTX_set_tmp_ecdh(m_ssl_context->native_handle(), ecdh);
-                            EC_KEY_free(ecdh);
-                        }
-                    }
+                    m_ssl_context->use_tmp_ecdh(m_ssl_settings->get_certificate());
                 }
 #endif
 

--- a/source/corvusoft/restbed/detail/service_impl.cpp
+++ b/source/corvusoft/restbed/detail/service_impl.cpp
@@ -244,6 +244,30 @@ namespace restbed
                 options = ( m_ssl_settings->has_enabled_single_diffie_hellman_use( ) ) ? options | asio::ssl::context::single_dh_use : options;
                 m_ssl_context->set_options( options );
                 
+#ifdef ECDHE_SUPPORT
+                if ( m_ssl_settings->has_enabled_single_ecc_diffie_hellman_use() )
+                {
+                    int nid = OBJ_sn2nid("prime256v1"); // FIXME: Only supports secp256r1; make more generic
+                    if( nid == 0 )
+                    {
+                        log( Logger::ERROR, "failed to find nid for ECDHE curve prime256v1");
+                    }
+                    else
+                    {
+                        EC_KEY *ecdh = EC_KEY_new_by_curve_name(nid);
+                        if(!ecdh)
+                        {
+                            log( Logger::ERROR, "failed to allocated new ECDH key");
+                        }
+                        else
+                        {
+                            SSL_CTX_set_tmp_ecdh(m_ssl_context->native_handle(), ecdh);
+                            EC_KEY_free(ecdh);
+                        }
+                    }
+                }
+#endif
+
                 if ( not m_ssl_settings->get_bind_address( ).empty( ) )
                 {
                     const auto address = address::from_string( m_ssl_settings->get_bind_address( ) );

--- a/source/corvusoft/restbed/detail/ssl_settings_impl.hpp
+++ b/source/corvusoft/restbed/detail/ssl_settings_impl.hpp
@@ -49,6 +49,10 @@ namespace restbed
             bool m_default_workarounds_enabled = true;
             
             bool m_single_diffie_hellman_use_enabled = true;
+
+#ifdef ECDHE_SUPPORT
+            bool m_single_ecc_diffie_hellman_use_enabled = true;
+#endif
             
             std::string m_bind_address = "";
             
@@ -65,6 +69,10 @@ namespace restbed
             std::string m_certificate_authority_pool = "";
             
             std::string m_temporary_diffie_hellman = "";
+
+#ifdef ECDHE_SUPPORT
+            std::string m_temporary_ecc_diffie_hellman = "";
+#endif
         };
     }
 }

--- a/source/corvusoft/restbed/detail/ssl_settings_impl.hpp
+++ b/source/corvusoft/restbed/detail/ssl_settings_impl.hpp
@@ -51,7 +51,7 @@ namespace restbed
             bool m_single_diffie_hellman_use_enabled = true;
 
 #ifdef ECDHE_SUPPORT
-            bool m_single_ecc_diffie_hellman_use_enabled = true;
+            bool m_ecc_diffie_hellman_use_enabled = false;
 #endif
             
             std::string m_bind_address = "";

--- a/source/corvusoft/restbed/ssl_settings.cpp
+++ b/source/corvusoft/restbed/ssl_settings.cpp
@@ -76,6 +76,13 @@ namespace restbed
     {
         return m_pimpl->m_single_diffie_hellman_use_enabled;
     }
+
+#ifdef ECDHE_SUPPORT
+    bool SSLSettings::has_enabled_single_ecc_diffie_hellman_use( void ) const
+    {
+        return m_pimpl->m_single_ecc_diffie_hellman_use_enabled;
+    }
+#endif
     
     uint16_t SSLSettings::get_port( void ) const
     {
@@ -211,4 +218,11 @@ namespace restbed
     {
         m_pimpl->m_temporary_diffie_hellman = String::remove( "file://", value.to_string( ), String::CASE_INSENSITIVE );
     }
+
+#ifdef ECDHE_SUPPORT
+    void SSLSettings::set_temporary_ecc_diffie_hellman( const bool value /* TODO: const string& curve */ )
+    {
+        m_pimpl->m_single_diffie_hellman_use_enabled = value;
+    }
+#endif
 }

--- a/source/corvusoft/restbed/ssl_settings.cpp
+++ b/source/corvusoft/restbed/ssl_settings.cpp
@@ -78,9 +78,9 @@ namespace restbed
     }
 
 #ifdef ECDHE_SUPPORT
-    bool SSLSettings::has_enabled_single_ecc_diffie_hellman_use( void ) const
+    bool SSLSettings::has_enabled_ecc_diffie_hellman_use( void ) const
     {
-        return m_pimpl->m_single_ecc_diffie_hellman_use_enabled;
+        return m_pimpl->m_ecc_diffie_hellman_use_enabled;
     }
 #endif
     
@@ -183,6 +183,13 @@ namespace restbed
     {
         m_pimpl->m_single_diffie_hellman_use_enabled = value;
     }
+
+#ifdef ECDHE_SUPPORT
+    void SSLSettings::set_ecc_diffie_hellman_use_enabled( const bool value )
+    {
+        m_pimpl->m_ecc_diffie_hellman_use_enabled = value;
+    }
+#endif
     
     void SSLSettings::set_certificate( const Uri& value )
     {
@@ -219,10 +226,4 @@ namespace restbed
         m_pimpl->m_temporary_diffie_hellman = String::remove( "file://", value.to_string( ), String::CASE_INSENSITIVE );
     }
 
-#ifdef ECDHE_SUPPORT
-    void SSLSettings::set_temporary_ecc_diffie_hellman( const bool value /* TODO: const string& curve */ )
-    {
-        m_pimpl->m_single_diffie_hellman_use_enabled = value;
-    }
-#endif
 }

--- a/source/corvusoft/restbed/ssl_settings.hpp
+++ b/source/corvusoft/restbed/ssl_settings.hpp
@@ -59,6 +59,9 @@ namespace restbed
             bool has_enabled_default_workarounds( void ) const;
             
             bool has_enabled_single_diffie_hellman_use( void ) const;
+#ifdef ECDHE_SUPPORT
+            bool has_enabled_single_ecc_diffie_hellman_use( void ) const;
+#endif
             
             //Getters
             uint16_t get_port( void ) const;
@@ -115,6 +118,9 @@ namespace restbed
             void set_private_rsa_key( const Uri& value );
             
             void set_temporary_diffie_hellman( const Uri& value );
+#ifdef ECDHE_SUPPORT
+            void set_temporary_ecc_diffie_hellman( bool value );
+#endif
             
             //Operators
             

--- a/source/corvusoft/restbed/ssl_settings.hpp
+++ b/source/corvusoft/restbed/ssl_settings.hpp
@@ -60,7 +60,7 @@ namespace restbed
             
             bool has_enabled_single_diffie_hellman_use( void ) const;
 #ifdef ECDHE_SUPPORT
-            bool has_enabled_single_ecc_diffie_hellman_use( void ) const;
+            bool has_enabled_ecc_diffie_hellman_use( void ) const;
 #endif
             
             //Getters
@@ -119,7 +119,7 @@ namespace restbed
             
             void set_temporary_diffie_hellman( const Uri& value );
 #ifdef ECDHE_SUPPORT
-            void set_temporary_ecc_diffie_hellman( bool value );
+            void set_ecc_diffie_hellman_use_enabled( bool value );
 #endif
             
             //Operators


### PR DESCRIPTION
Implements ECDHE support in RestBed, but requires the version of ASIO that incorporates: chriskohlhoff/asio#117

Might be a bit until that happens; but the change is here none the less.

In the mean time, you may be able to cherry-pick 0903c62, which implements a proof-of-concept version hardcoded to work with secp256r1 (P-256 curve).

Fixes #86.
