### PR TITLE
Using std::unique_ptr to clean up instead of delete

### DIFF
--- a/example/compression/source/example.cpp
+++ b/example/compression/source/example.cpp
@@ -32,19 +32,17 @@ void deflate_method_handler( const shared_ptr< Session > session )
         if ( request->get_header( "Content-Encoding", String::lowercase ) == "deflate" )
         {
             mz_ulong length = compressBound( static_cast< mz_ulong >( body.size( ) ) );
-            unsigned char* data = new unsigned char[ length ];
-            const int status = uncompress( data, &length, body.data( ), static_cast< mz_ulong >( body.size( ) ) );
+            std::unique_ptr<unsigned char[]> data (new unsigned char[length]);
+            const int status = uncompress( data.get(), &length, body.data( ), static_cast< mz_ulong >( body.size( ) ) );
             
             if ( status not_eq MZ_OK )
             {
                 const auto message = String::format( "Failed to deflate: %s\n", mz_error( status ) );
                 session->close( 400, message, { { "Content-Length", ::to_string( message.length( ) ) }, { "Content-Type", "text/plain" } } );
-                delete[ ] data;
                 return;
             }
             
-            result = Bytes( data, data + length );
-            delete[ ] data;
+            result = Bytes( data.get(), data.get() + length );
         }
         
         session->close( 200, result, { { "Content-Length", ::to_string( result.size( ) ) }, { "Content-Type", "text/plain" } } );

--- a/source/corvusoft/restbed/string.cpp
+++ b/source/corvusoft/restbed/string.cpp
@@ -158,17 +158,16 @@ namespace restbed
     
     string::size_type String::format( string& output, const string::size_type length, const char* format, va_list arguments )
     {
-        char* formatted = new char[ length + 1 ];
+		std::unique_ptr<char[]> formatted (new char[ length + 1 ]);
         
-        int required_length = vsnprintf( formatted, length + 1, format, arguments );
+        int required_length = vsnprintf( formatted.get(), length + 1, format, arguments );
         
         if ( required_length == -1 )
         {
             required_length = 0;
         }
         
-        output = formatted;
-        delete[ ] formatted;
+        output = formatted.get();
         
         return required_length;
     }


### PR DESCRIPTION
Using std::unique_ptr to clean up instead of delete in two files as issued in here #98 