### PR TITLE
Fixed error: #elif with no expression

### DIFF
--- a/example/signal_handling/source/example.cpp
+++ b/example/signal_handling/source/example.cpp
@@ -17,7 +17,7 @@
 
 #ifdef _WIN32
     #include <process.h>
-#elif
+#else
     #include <unistd.h>
 #endif
 


### PR DESCRIPTION
Fixed error: #elif with no expression
Linking CXX executable example/serving_html