### PR TITLE
Never allow completion handlers for async_read() and async_write() to…

### DIFF
--- a/source/corvusoft/restbed/detail/socket_impl.cpp
+++ b/source/corvusoft/restbed/detail/socket_impl.cpp
@@ -4,7 +4,6 @@
 
 //System Includes
 #include <ciso646>
-#include <stdexcept>
 
 //Project Includes
 #include "corvusoft/restbed/logger.hpp"
@@ -15,14 +14,13 @@
 #include <asio/write.hpp>
 #include <asio/connect.hpp>
 #include <asio/read_until.hpp>
-#include <asio/io_service.hpp>
+
 
 //System Namespaces
 using std::bind;
 using std::size_t;
 using std::string;
 using std::function;
-using std::exception;
 using std::to_string;
 using std::error_code;
 using std::shared_ptr;
@@ -52,6 +50,7 @@ namespace restbed
             m_logger( logger ),
             m_timeout( 0 ),
             m_timer( make_shared< asio::steady_timer >( socket->get_io_service( ) ) ),
+            m_strand( make_shared< io_service::strand > ( socket->get_io_service( ) ) ),
             m_resolver( nullptr ),
             m_socket( socket )
 #ifdef BUILD_SSL
@@ -66,6 +65,7 @@ namespace restbed
             m_logger( logger ),
             m_timeout( 0 ),
             m_timer( make_shared< asio::steady_timer >( socket->lowest_layer( ).get_io_service( ) ) ),
+            m_strand( make_shared< io_service::strand > ( socket->get_io_service( ) ) ),
             m_resolver( nullptr ),
             m_socket( nullptr ),
             m_ssl_socket( socket )
@@ -73,46 +73,46 @@ namespace restbed
             return;
         }
 #endif
-
+        
         SocketImpl::~SocketImpl( void )
         {
             return;
         }
-
+        
         void SocketImpl::close( void )
         {
             m_is_open = false;
-
+            
             if ( m_timer not_eq nullptr )
             {
                 m_timer->cancel( );
             }
-
+            
             if ( m_socket not_eq nullptr )
             {
                 m_socket->close( );
             }
-
+            
 #ifdef BUILD_SSL
-
+            
             if ( m_ssl_socket not_eq nullptr )
             {
                 m_ssl_socket->lowest_layer( ).close( );
             }
-
+            
 #endif
         }
-
+        
         bool SocketImpl::is_open( void ) const
         {
             return m_is_open;
         }
-
+        
         bool SocketImpl::is_closed( void ) const
         {
             return not m_is_open;
         }
-
+        
         void SocketImpl::connect( const string& hostname, const uint16_t port, const function< void ( const error_code& ) >& callback )
         {
 #ifdef BUILD_SSL
@@ -121,9 +121,8 @@ namespace restbed
             auto& io_service = m_socket->get_io_service( );
 #endif
             m_resolver = make_shared< tcp::resolver >( io_service );
-
             tcp::resolver::query query( hostname, ::to_string( port ) );
-
+            
             m_resolver->async_resolve( query, [ this, callback ]( const error_code & error, tcp::resolver::iterator endpoint_iterator )
             {
                 if ( not error )
@@ -136,12 +135,12 @@ namespace restbed
                     asio::async_connect( socket, endpoint_iterator, [ this, callback ]( const error_code & error, tcp::resolver::iterator )
                     {
 #ifdef BUILD_SSL
-
+                    
                         if ( m_ssl_socket not_eq nullptr )
                         {
                             m_ssl_socket->handshake( asio::ssl::stream_base::client );
                         }
-
+                        
 #endif
                         m_is_open = true;
                         callback( error );
@@ -149,77 +148,77 @@ namespace restbed
                 }
             } );
         }
-
+        
         void SocketImpl::sleep_for( const milliseconds& delay, const function< void ( const error_code& ) >& callback )
         {
             m_timer->cancel( );
             m_timer->expires_from_now( delay );
             m_timer->async_wait( callback );
         }
-
+        
         void SocketImpl::write( const Bytes& data, const function< void ( const error_code&, size_t ) >& callback )
         {
             m_buffer = make_shared< Bytes >( data );
 
             m_timer->cancel( );
             m_timer->expires_from_now( m_timeout );
-            m_timer->async_wait( bind( &SocketImpl::connection_timeout_handler,  shared_from_this( ), _1 ) );
+            m_timer->async_wait( m_strand->wrap( bind( &SocketImpl::connection_timeout_handler, this, _1 ) ) );
 
 #ifdef BUILD_SSL
-
+            
             if ( m_socket not_eq nullptr )
             {
 #endif
-                asio::async_write( *m_socket, asio::buffer( m_buffer->data( ), m_buffer->size( ) ), [ this, callback ]( const error_code & error, size_t length )
+                asio::async_write( *m_socket, asio::buffer( m_buffer->data( ), m_buffer->size( ) ), m_strand->wrap( [ this, callback ]( const error_code & error, size_t length )
                 {
                     m_timer->cancel( );
-
+                    
                     if ( error )
                     {
                         m_is_open = false;
                     }
-
+                    
                     m_buffer.reset( );
-
+                    
                     if ( error not_eq asio::error::operation_aborted )
                     {
                         callback( error, length );
                     }
-                } );
+                } ) );
 #ifdef BUILD_SSL
             }
             else
             {
-                asio::async_write( *m_ssl_socket, asio::buffer( m_buffer->data( ), m_buffer->size( ) ), [ this, callback ]( const error_code & error, size_t length )
+                asio::async_write( *m_ssl_socket, asio::buffer( m_buffer->data( ), m_buffer->size( ) ), m_strand->wrap( [ this, callback ]( const error_code & error, size_t length )
                 {
                     m_timer->cancel( );
-
+                    
                     if ( error )
                     {
                         m_is_open = false;
                     }
-
+                    
                     m_buffer.reset( );
-
+                    
                     if ( error not_eq asio::error::operation_aborted )
                     {
                         callback( error, length );
                     }
-                } );
+                } ) );
             }
-
+            
 #endif
         }
-
+        
         size_t SocketImpl::read( const shared_ptr< asio::streambuf >& data, const size_t length, error_code& error )
         {
             m_timer->cancel( );
             m_timer->expires_from_now( m_timeout );
-            m_timer->async_wait( bind( &SocketImpl::connection_timeout_handler,  shared_from_this( ), _1 ) );
+            m_timer->async_wait( bind( &SocketImpl::connection_timeout_handler, this, _1 ) );
 
             size_t size = 0;
 #ifdef BUILD_SSL
-
+            
             if ( m_socket not_eq nullptr )
             {
 #endif
@@ -230,76 +229,76 @@ namespace restbed
             {
                 size = asio::read( *m_ssl_socket, *data, asio::transfer_at_least( length ), error );
             }
-
+            
 #endif
             m_timer->cancel( );
-
+            
             if ( error )
             {
                 m_is_open = false;
             }
-
+            
             return size;
         }
-
+        
         void SocketImpl::read( const shared_ptr< asio::streambuf >& data, const size_t length, const function< void ( const error_code&, size_t ) >& callback )
         {
             m_timer->cancel( );
             m_timer->expires_from_now( m_timeout );
-            m_timer->async_wait( bind( &SocketImpl::connection_timeout_handler,  shared_from_this( ), _1 ) );
+            m_timer->async_wait( m_strand->wrap( bind( &SocketImpl::connection_timeout_handler, this, _1 ) ) );
 
 #ifdef BUILD_SSL
-
+            
             if ( m_socket not_eq nullptr )
             {
 #endif
-                asio::async_read( *m_socket, *data, asio::transfer_at_least( length ), [ this, callback ]( const error_code & error, size_t length )
+                asio::async_read( *m_socket, *data, asio::transfer_at_least( length ), m_strand->wrap( [ this, callback ]( const error_code & error, size_t length )
                 {
                     m_timer->cancel( );
-
+                    
                     if ( error )
                     {
                         m_is_open = false;
                     }
-
+                    
                     if ( error not_eq asio::error::operation_aborted )
                     {
                         callback( error, length );
                     }
-                } );
+                } ) );
 #ifdef BUILD_SSL
             }
             else
             {
-                asio::async_read( *m_ssl_socket, *data, asio::transfer_at_least( length ), [ this, callback ]( const error_code & error, size_t length )
+                asio::async_read( *m_ssl_socket, *data, asio::transfer_at_least( length ), m_strand->wrap( [ this, callback ]( const error_code & error, size_t length )
                 {
                     m_timer->cancel( );
-
+                    
                     if ( error )
                     {
                         m_is_open = false;
                     }
-
+                    
                     if ( error not_eq asio::error::operation_aborted )
                     {
                         callback( error, length );
                     }
-                } );
+                } ) );
             }
-
+            
 #endif
         }
-
+        
         size_t SocketImpl::read( const shared_ptr< asio::streambuf >& data, const string& delimiter, error_code& error )
         {
             m_timer->cancel( );
             m_timer->expires_from_now( m_timeout );
-            m_timer->async_wait( bind( &SocketImpl::connection_timeout_handler,  shared_from_this( ), _1 ) );
-
+            m_timer->async_wait( bind( &SocketImpl::connection_timeout_handler, this, _1 ) );
+            
             size_t length = 0;
-
+            
 #ifdef BUILD_SSL
-
+            
             if ( m_socket not_eq nullptr )
             {
 #endif
@@ -310,72 +309,72 @@ namespace restbed
             {
                 length = asio::read_until( *m_ssl_socket, *data, delimiter, error );
             }
-
+            
 #endif
             m_timer->cancel( );
-
+            
             if ( error )
             {
                 m_is_open = false;
             }
-
+            
             return length;
         }
-
+        
         void SocketImpl::read( const shared_ptr< asio::streambuf >& data, const string& delimiter, const function< void ( const error_code&, size_t ) >& callback )
         {
             m_timer->cancel( );
             m_timer->expires_from_now( m_timeout );
-            m_timer->async_wait( bind( &SocketImpl::connection_timeout_handler,  shared_from_this( ), _1 ) );
-
+            m_timer->async_wait( m_strand->wrap( bind( &SocketImpl::connection_timeout_handler, this, _1 ) ) );
+            
 #ifdef BUILD_SSL
-
+            
             if ( m_socket not_eq nullptr )
             {
 #endif
-                asio::async_read_until( *m_socket, *data, delimiter, [ this, callback ]( const error_code & error, size_t length )
+                asio::async_read_until( *m_socket, *data, delimiter, m_strand->wrap( [ this, callback ]( const error_code & error, size_t length )
                 {
                     m_timer->cancel( );
-
+                    
                     if ( error )
                     {
                         m_is_open = false;
                     }
-
+                    
                     if ( error not_eq asio::error::operation_aborted )
                     {
                         callback( error, length );
                     }
-                } );
+                } ) );
 #ifdef BUILD_SSL
             }
             else
             {
-                asio::async_read_until( *m_ssl_socket, *data, delimiter, [ this, callback ]( const error_code & error, size_t length )
+                asio::async_read_until( *m_ssl_socket, *data, delimiter, m_strand->wrap( [ this, callback ]( const error_code & error, size_t length )
                 {
                     m_timer->cancel( );
-
+                    
                     if ( error )
                     {
                         m_is_open = false;
                     }
-
+                    
                     if ( error not_eq asio::error::operation_aborted )
                     {
                         callback( error, length );
                     }
-                } );
+                } ) );
             }
-
+            
 #endif
         }
-
+        
         string SocketImpl::get_local_endpoint( void )
         {
             error_code error;
             tcp::endpoint endpoint;
 #ifdef BUILD_SSL
-
+            
             if ( m_socket not_eq nullptr )
             {
 #endif
@@ -386,27 +385,27 @@ namespace restbed
             {
                 endpoint = m_ssl_socket->lowest_layer( ).local_endpoint( error );
             }
-
+            
 #endif
-
+            
             if ( error )
             {
                 m_is_open = false;
             }
-
+            
             auto address = endpoint.address( );
-            auto local = address.is_v4( ) ? address.to_string( ) + ":" : "[" + address.to_string( ) + "]:";
+            auto local = address.is_v4( ) ? address.to_string( ) : "[" + address.to_string( ) + "]:";
             local += ::to_string( endpoint.port( ) );
-
+            
             return local;
         }
-
+        
         string SocketImpl::get_remote_endpoint( void )
         {
             error_code error;
             tcp::endpoint endpoint;
 #ifdef BUILD_SSL
-
+            
             if ( m_socket not_eq nullptr )
             {
 #endif
@@ -417,39 +416,34 @@ namespace restbed
             {
                 endpoint = m_ssl_socket->lowest_layer( ).remote_endpoint( error );
             }
-
+            
 #endif
-
+            
             if ( error )
             {
                 m_is_open = false;
             }
-
+            
             auto address = endpoint.address( );
-            auto remote = address.is_v4( ) ? address.to_string( ) + ":" : "[" + address.to_string( ) + "]:";
+            auto remote = address.is_v4( ) ? address.to_string( ) : "[" + address.to_string( ) + "]:";
             remote += ::to_string( endpoint.port( ) );
-
+            
             return remote;
         }
-
+        
         void SocketImpl::set_timeout( const milliseconds& value )
         {
             m_timeout = value;
         }
-
-        void SocketImpl::connection_timeout_handler( const shared_ptr< SocketImpl > socket, const error_code& error )
+        
+        void SocketImpl::connection_timeout_handler( const error_code& error )
         {
-            if ( socket == nullptr )
+            if ( error or m_timer->expires_at( ) > steady_clock::now( ) )
             {
                 return;
             }
-
-            if ( error or socket->m_timer->expires_at( ) > steady_clock::now( ) )
-            {
-                return;
-            }
-
-            socket->close( );
+            
+            close( );
         }
     }
 }

--- a/source/corvusoft/restbed/detail/socket_impl.hpp
+++ b/source/corvusoft/restbed/detail/socket_impl.hpp
@@ -20,6 +20,9 @@
 #include <asio/ip/tcp.hpp>
 #include <asio/streambuf.hpp>
 #include <asio/steady_timer.hpp>
+#include <asio/io_service.hpp>
+#include <asio/io_service_strand.hpp>
+
 
 #ifdef BUILD_SSL
     #include <asio/ssl.hpp>
@@ -40,7 +43,7 @@ namespace restbed
     {
         //Forward Declarations
         
-        class SocketImpl : public std::enable_shared_from_this< SocketImpl >
+        class SocketImpl
         {
             public:
                 //Friends
@@ -113,8 +116,8 @@ namespace restbed
                 SocketImpl( const SocketImpl& original ) = delete;
                 
                 //Functionality
-                static void connection_timeout_handler( const std::shared_ptr< SocketImpl > socket, const std::error_code& error );
-                
+                void connection_timeout_handler( const std::error_code& error );
+
                 //Getters
                 
                 //Setters
@@ -132,7 +135,9 @@ namespace restbed
                 std::chrono::milliseconds m_timeout;
                 
                 std::shared_ptr< asio::steady_timer > m_timer;
-                
+
+                std::shared_ptr< asio::io_service::strand > m_strand;
+
                 std::shared_ptr< asio::ip::tcp::resolver > m_resolver;
                 
                 std::shared_ptr< asio::ip::tcp::socket > m_socket;


### PR DESCRIPTION
… run concurrently with connection_timeout_handler() because that is a race condition. Fixes Corvusoft/restbed#125