### PR TITLE
Renamed set_header() to add_header() and reimplemented set_header() so…

### DIFF
--- a/source/corvusoft/restbed/request.cpp
+++ b/source/corvusoft/restbed/request.cpp
@@ -245,9 +245,15 @@ namespace restbed
     {
         m_pimpl->m_protocol = value;
     }
-    
+
+    void Request::add_header( const string& name, const string& value )
+    {
+        m_pimpl->m_headers.insert( make_pair( name, value ) );
+    }
+
     void Request::set_header( const string& name, const string& value )
     {
+        m_pimpl->m_headers.erase( name );
         m_pimpl->m_headers.insert( make_pair( name, value ) );
     }
     

--- a/source/corvusoft/restbed/request.hpp
+++ b/source/corvusoft/restbed/request.hpp
@@ -133,7 +133,9 @@ namespace restbed
             void set_method( const std::string& value );
             
             void set_protocol( const std::string& value );
-            
+
+            void add_header( const std::string& name, const std::string& value );
+
             void set_header( const std::string& name, const std::string& value );
             
             void set_headers( const std::multimap< std::string, std::string >& values );

--- a/source/corvusoft/restbed/response.cpp
+++ b/source/corvusoft/restbed/response.cpp
@@ -132,11 +132,17 @@ namespace restbed
         m_pimpl->m_status_message = value;
     }
     
-    void Response::set_header( const string& name, const string& value )
+    void Response::add_header( const string& name, const string& value )
     {
         m_pimpl->m_headers.insert( make_pair( name, value ) );
     }
-    
+
+    void Response::set_header( const string& name, const string& value )
+    {
+        m_pimpl->m_headers.erase( name );
+        m_pimpl->m_headers.insert( make_pair( name, value ) );
+    }
+
     void Response::set_headers( const multimap< string, string >& values )
     {
         m_pimpl->m_headers = values;

--- a/source/corvusoft/restbed/response.hpp
+++ b/source/corvusoft/restbed/response.hpp
@@ -86,7 +86,9 @@ namespace restbed
             void set_protocol( const std::string& protocol );
             
             void set_status_message( const std::string& value );
-            
+
+            void add_header( const std::string& name, const std::string& value );
+
             void set_header( const std::string& name, const std::string& value );
             
             void set_headers( const std::multimap< std::string, std::string >& values );

--- a/source/corvusoft/restbed/session.cpp
+++ b/source/corvusoft/restbed/session.cpp
@@ -433,11 +433,17 @@ namespace restbed
         m_pimpl->m_context.insert( make_pair( name, value ) );
     }
     
-    void Session::set_header( const string& name, const string& value )
+    void Session::add_header( const string& name, const string& value )
     {
         m_pimpl->m_headers.insert( make_pair( name, value ) );
     }
-    
+
+    void Session::set_header( const string& name, const string& value )
+    {
+        m_pimpl->m_headers.erase( name );
+        m_pimpl->m_headers.insert( make_pair( name, value ) );
+    }
+
     void Session::set_headers( const multimap< string, string >& values )
     {
         m_pimpl->m_headers = values;

--- a/source/corvusoft/restbed/session.hpp
+++ b/source/corvusoft/restbed/session.hpp
@@ -122,7 +122,9 @@ namespace restbed
             void set_id( const std::string& value );
             
             void set( const std::string& name, const ContextValue& value );
-            
+
+            void add_header( const std::string& name, const std::string& value );
+
             void set_header( const std::string& name, const std::string& value );
             
             void set_headers( const std::multimap< std::string, std::string >& values );


### PR DESCRIPTION
… that it erases any previous headers with the same name, i.e. has overwrite semantics. Fixes Corvusoft/restbed#123