### PR TITLE
fix build when using boost 1.61

### DIFF
--- a/source/corvusoft/restbed/detail/socket_impl.hpp
+++ b/source/corvusoft/restbed/detail/socket_impl.hpp
@@ -17,12 +17,18 @@
 #include "corvusoft/restbed/byte.hpp"
 
 //External Includes
+
 #include <asio/ip/tcp.hpp>
 #include <asio/streambuf.hpp>
 #include <asio/steady_timer.hpp>
 #include <asio/io_service.hpp>
-#include <asio/io_service_strand.hpp>
 
+#include <boost/version.hpp>
+#if BOOST_VERSION >= 106100
+#include <asio/strand.hpp>
+#else
+#include <asio/io_service_strand.hpp>
+#endif
 
 #ifdef BUILD_SSL
     #include <asio/ssl.hpp>

--- a/source/corvusoft/restbed/detail/socket_impl.hpp
+++ b/source/corvusoft/restbed/detail/socket_impl.hpp
@@ -23,7 +23,7 @@
 #include <asio/steady_timer.hpp>
 #include <asio/io_service.hpp>
 
-#include <boost/version.hpp>
+#include <../version.hpp>
 #if BOOST_VERSION >= 106100
 #include <asio/strand.hpp>
 #else


### PR DESCRIPTION
Hi,

I fixed the build when we use boost 1.61. The io_service_strand.hpp header is strand.hpp now.