### PR TITLE
Remove defunct sessions (replace #175)

### DIFF
--- a/example/server_sent_events/source/example.cpp
+++ b/example/server_sent_events/source/example.cpp
@@ -47,6 +47,13 @@ void event_stream_handler( void )
 	static size_t counter = 0;
 	const auto message = "data: event " + to_string( counter ) + "\n\n";
 
+	sessions.erase(
+		  std::remove_if(sessions.begin(), sessions.end(),
+                                [](const shared_ptr<Session> &a) {
+                                  return a->is_closed();
+                                }),
+		  sessions.end());
+
 	for ( auto session : sessions )
 	{
 		session->yield( message );


### PR DESCRIPTION
There is a memory leak on this example.

Maybe there is a better fix, or maybe the session API shall allow a close callback like the websocket API.