### PR TITLE
Small build files cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,11 +32,10 @@ matrix:
 before_script:
   - if [ -n "$COMPILERC" ]; then export CC=$COMPILERC; fi
   - if [ -n "$COMPILERCXX" ]; then export CXX=$COMPILERCXX; fi 
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export OPENSSL_ROOT_DIR=/usr/local/opt/openssl; fi
   - mkdir build
   - cd build
   - cmake -DBUILD_EXAMPLES=YES -DBUILD_TESTS=YES -DBUILD_SSL=YES ..
-  
+
 script: make -j3 && make test
 
 notifications:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright 2013-2017, Corvusoft Ltd, All Rights Reserved.
 cmake_minimum_required( VERSION 2.8.10 )
 
-project( "restbed" )
+project( restbed CXX )
 set( restbed_VERSION_MAJOR 4 )
 set( restbed_VERSION_MINOR 5.0 )
 set( restbed_VERSION ${restbed_VERSION_MAJOR}.${restbed_VERSION_MINOR} )


### PR DESCRIPTION
With your find openssl module, there is no need for a specific configuration at Travis.

Also set the project to CXX at cmake.

Signed-off-by: Nuno Goncalves <nunojpg@gmail.com>