### PR TITLE
Handle DNS resolution error

### DIFF
--- a/source/corvusoft/restbed/detail/socket_impl.cpp
+++ b/source/corvusoft/restbed/detail/socket_impl.cpp
@@ -145,6 +145,8 @@ namespace restbed
                         m_is_open = true;
                         callback( error );
                     } );
+                } else {
+                    callback( error );
                 }
             } );
         }


### PR DESCRIPTION
DNS resolution error currently causes indefinite hangup as the callback is not called and higher-level layers are not informed.

This commit bubbles up the error, allowing the request to fail.

The issue is easy to reproduce: simply turn off networking and attempt to perform
an HTTP request. The request will never end and no error will be reported.