### PR TITLE
Win32: use _WIN32 macro, proper case for winsock2.h

### DIFF
--- a/source/corvusoft/restbed/logger.hpp
+++ b/source/corvusoft/restbed/logger.hpp
@@ -5,7 +5,7 @@
 #ifndef _RESTBED_LOGGER_H
 #define _RESTBED_LOGGER_H 1
 
-#if defined(WIN32)
+#if defined(_WIN32)
     #undef ERROR
 #endif
 

--- a/source/corvusoft/restbed/uri.cpp
+++ b/source/corvusoft/restbed/uri.cpp
@@ -8,9 +8,9 @@
 #include <cstdlib>
 #include <stdexcept>
 
-#if defined(WIN32)
+#if defined(_WIN32)
     #include <ciso646>
-    #include <Winsock2.h>
+    #include <winsock2.h>
     #pragma comment( lib, "Ws2_32.lib" )
 #else
     #include <netdb.h>


### PR DESCRIPTION
Fix various issues preventing compilation in some environments
(e.g. cross-compiling with mingw) on a case-sensitive system,
and use the official _WIN32 macro to detect the Win32 environment as WIN32 is not always defined.