### PR TITLE
ensure HTTP version is well formatted

### DIFF
--- a/source/corvusoft/restbed/string.cpp
+++ b/source/corvusoft/restbed/string.cpp
@@ -7,6 +7,7 @@
 #include <memory>
 #include <ciso646>
 #include <algorithm>
+#include <cstdlib>
 
 //Project Includes
 #include "corvusoft/restbed/string.hpp"
@@ -162,8 +163,14 @@ namespace restbed
     {
         unique_ptr< char[ ] > formatted( new char[ length + 1 ] );
         
+        char* saved_locale = strdup(setlocale(LC_NUMERIC, NULL));
+        setlocale(LC_NUMERIC, "C");
+
         int required_length = vsnprintf( formatted.get( ), length + 1, format, arguments );
         
+        setlocale(LC_NUMERIC, saved_locale);
+        free(saved_locale);
+
         if ( required_length == -1 )
         {
             required_length = 0;


### PR DESCRIPTION
Some locales use a comma ',' instead of a dot '.' as a delimiter
between integer and fractional part. If a program using restbed uses
such a locale, the HTTP version sent in a request will contain a comma
and fail (like "HTTP/1,1" instead of "HTTP/1.1").

Ensuring we use the default C locale for LC_NUMERIC prevents an
incorrect formatting of version number. After the vsnprintf call, the
old locale is restored to its old value thus preserving any
modification.