### PR TITLE
http: check for locale before duplicating string

### DIFF
--- a/source/corvusoft/restbed/detail/http_impl.cpp
+++ b/source/corvusoft/restbed/detail/http_impl.cpp
@@ -96,17 +96,23 @@ namespace restbed
                 protocol = "HTTP";
             }
             
-            char* locale = strdup( setlocale( LC_NUMERIC, nullptr ) );
-            setlocale( LC_NUMERIC, "C" );
+            char* locale = nullptr;
+            if (auto current_locale = setlocale( LC_NUMERIC, nullptr ) )
+            {
+                locale = strdup(current_locale);
+                setlocale( LC_NUMERIC, "C" );
+            }
             
             auto data = String::format( "%s %s %s/%.1f\r\n",
                                         request->get_method( ).data( ),
                                         path.data( ),
                                         protocol.data( ),
                                         request->get_version( ) );
-                                        
-            setlocale( LC_NUMERIC, locale );
-            free( locale );
+            
+            if (locale) {
+                setlocale( LC_NUMERIC, locale );
+                free( locale );
+            }
             
             auto headers = request->get_headers( );
             

--- a/source/corvusoft/restbed/http.cpp
+++ b/source/corvusoft/restbed/http.cpp
@@ -62,17 +62,23 @@ namespace restbed
     
     Bytes Http::to_bytes( const shared_ptr< Response >& value )
     {
-        char* locale = strdup( setlocale( LC_NUMERIC, nullptr ) );
-        setlocale( LC_NUMERIC, "C" );
+        char* locale = nullptr;
+        if (auto current_locale = setlocale( LC_NUMERIC, nullptr ) )
+        {
+            locale = strdup(current_locale);
+            setlocale( LC_NUMERIC, "C" );
+        }
         
         auto data = String::format( "%s/%.1f %i %s\r\n",
                                     value->get_protocol( ).data( ),
                                     value->get_version( ),
                                     value->get_status_code( ),
                                     value->get_status_message( ).data( ) );
-                                    
-        setlocale( LC_NUMERIC, locale );
-        free( locale );
+        
+        if (locale) {
+            setlocale( LC_NUMERIC, locale );
+            free( locale );
+        }
         
         auto headers = value->get_headers( );
         


### PR DESCRIPTION
On Restbed 4.6, Android users (4.3, 4.4) experienced crashes with the following backtrace:
```
signal 11 (SIGSEGV), code 1 (SEGV_MAPERR)
  native: pc 0000000000022fc8  /system/lib/libc.so (strlen+83)
  native: pc 000000000002b9ed  /system/lib/libc.so (strdup+4)
  native: pc 00000000006d4a07  /data/app-lib/cx.ring-2/libring.so (restbed::detail::HttpImpl::to_bytes(std::__ndk1::shared_ptr<restbed::Request> const&)+1578)
```

strdup is only used once in HttpImpl::to_bytes:
```c++
char* locale = strdup( setlocale( LC_NUMERIC, nullptr ) );
```

Excluding a bug in libc, the only possible reason of the crash is setlocale returning a null/invalid pointer.

This case should be handled since documentation for setlocale says:
> The return value is NULL if the request cannot be honored.