### PR TITLE
Add SSL Client Authentication

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,14 +29,14 @@ message( "   ${Blue}Copyright 2013-2017, Corvusoft Ltd, All Rights Reserved.${Re
 set( CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${PROJECT_SOURCE_DIR}/cmake/modules" )
 
 find_package( asio REQUIRED )
-include_directories( SYSTEM ${asio_INCLUDE} )
+include_directories( ${asio_INCLUDE} )
 
 find_package( kashmir REQUIRED )
-include_directories( SYSTEM ${kashmir_INCLUDE} )
+include_directories( ${kashmir_INCLUDE} )
 
 if ( BUILD_SSL )
     find_package( openssl REQUIRED )
-    include_directories( SYSTEM ${ssl_INCLUDE} )
+    include_directories( ${ssl_INCLUDE} )
 endif ( )
 
 #

--- a/example/https_client/source/client_auth.cpp
+++ b/example/https_client/source/client_auth.cpp
@@ -1,0 +1,81 @@
+/*
+ * Example illustrating a HTTPS client authentication
+ *
+ * 0. Generate a CA
+ *    mkdir -p /tmp/ssl/{client,server,CA}
+ *    openssl genrsa -out /tmp/ssl/CA/ca.key 4096 
+ *    openssl req -x509 -new -nodes -key /tmp/ssl/CA/ca.key -sha256 -days 1024 -out /tmp/ssl/CA/ca.pem -subj '/C=US/ST=Oregon/L=Portland/CN=FAKE ROOT'
+ *    ln -s /tmp/ssl/CA/ca.pem /tmp/ssl/CA/`openssl x509 -hash -in /tmp/ssl/CA/ca.pem -noout`.0
+ *
+ * 1. genereate key and certificate:
+ *
+ *    openssl req -nodes -new -newkey rsa:2048 -keyout /tmp/ssl/client/key.key -out /tmp/ssl/client/certificate.csr -subj '/C=US/ST=Oregon/L=Portland/CN=Client'
+ *
+ *    openssl req -nodes -new -newkey rsa:2048 -keyout /tmp/ssl/server/key.key -out /tmp/ssl/server/certificate.csr -subj '/C=US/ST=Oregon/L=Portland/CN=localhost'
+ *
+ *    openssl x509 -req -in /tmp/ssl/client/certificate.csr -CA /tmp/ssl/CA/ca.pem -CAkey /tmp/ssl/CA/ca.key -CAcreateserial -days 500 -sha256 -out /tmp/ssl/client/certificate.crt
+ *
+ *    openssl x509 -req -in /tmp/ssl/server/certificate.csr -CA /tmp/ssl/CA/ca.pem -CAkey /tmp/ssl/CA/ca.key -CAcreateserial -days 500 -sha256 -out /tmp/ssl/server/certificate.crt
+ *
+ *    openssl dhparam 2048 -out /tml/ssl/client/dhparam.pem -outform PEM
+ * 
+ *
+ * 2. start openssl debug server
+ *    openssl s_server -accept 8080 -www -cert /tmp/ssl/server/certificate.crt -key /tmp/ssl/server/key.key -CApath /tmp/ssl/CA/ -tls1 -verify 2
+ *
+ * Usage:
+ *    ./distribution/example/https_client_authentication
+ */
+
+#include <memory>
+#include <cstdio>
+#include <cstdlib>
+#include <restbed>
+
+using namespace std;
+using namespace restbed;
+
+int main( const int, const char** )
+{
+    auto request = make_shared< Request >( Uri( "https://localhost:8080" ) );
+    request->set_header( "Accept", "*/*" );
+    request->set_header( "Host", "localhost" );
+    
+    auto ssl_settings = make_shared< SSLSettings >( );
+    ssl_settings->set_client_authentication_enabled( true );
+    ssl_settings->set_private_key( Uri( "file:///tmp/ssl/client/key.key" ) );
+    ssl_settings->set_certificate( Uri( "file:///tmp/ssl/client/certificate.crt" ) );
+    ssl_settings->set_certificate_authority_pool( Uri( "file:///tmp/ssl/CA/" ) );
+    
+    auto settings = make_shared< Settings >( );
+    settings->set_ssl_settings( ssl_settings );
+    
+    auto response = Http::sync( request, settings );
+    
+    fprintf( stderr, "*** Response ***\n" );
+    fprintf( stderr, "Status Code:    %i\n", response->get_status_code( ) );
+    fprintf( stderr, "Status Message: %s\n", response->get_status_message( ).data( ) );
+    fprintf( stderr, "HTTP Version:   %.1f\n", response->get_version( ) );
+    fprintf( stderr, "HTTP Protocol:  %s\n", response->get_protocol( ).data( ) );
+    
+    for ( const auto header : response->get_headers( ) )
+    {
+        fprintf( stderr, "Header '%s' > '%s'\n", header.first.data( ), header.second.data( ) );
+    }
+    
+    if ( response->has_header( "Transfer-Encoding" ) )
+    {
+        Http::fetch( "\r\n", response );
+    }
+    else
+    {
+        auto length = 0;
+        response->get_header( "Content-Length", length );
+        
+        Http::fetch( length, response );
+    }
+    
+    fprintf( stderr, "Body:           %.*s...\n", 3, response->get_body( ).data( ) );
+    
+    return EXIT_SUCCESS;
+}

--- a/source/corvusoft/restbed/detail/service_impl.cpp
+++ b/source/corvusoft/restbed/detail/service_impl.cpp
@@ -239,6 +239,11 @@ namespace restbed
                 {
                     m_ssl_context->use_rsa_private_key_file( filename, asio::ssl::context::pem );
                 }
+
+                if ( m_ssl_settings->has_enabled_client_authentication( ) ) 
+                {
+                    m_ssl_context->set_verify_mode ( asio::ssl::verify_peer | asio::ssl::verify_fail_if_no_peer_cert );
+                }
                 
                 asio::ssl::context::options options = 0;
                 options = ( m_ssl_settings->has_enabled_tlsv1( ) ) ? options : options | asio::ssl::context::no_tlsv1;

--- a/source/corvusoft/restbed/detail/ssl_settings_impl.hpp
+++ b/source/corvusoft/restbed/detail/ssl_settings_impl.hpp
@@ -50,6 +50,10 @@ namespace restbed
             
             bool m_single_diffie_hellman_use_enabled = true;
             
+            bool m_client_authentication_enabled = false;
+            
+            bool m_server_authentication_enabled = true;
+            
             std::string m_bind_address = "";
             
             std::string m_passphrase = "";
@@ -65,6 +69,8 @@ namespace restbed
             std::string m_certificate_authority_pool = "";
             
             std::string m_temporary_diffie_hellman = "";
+
+	    std::string m_cipher_suites = "";
         };
     }
 }

--- a/source/corvusoft/restbed/ssl_settings.cpp
+++ b/source/corvusoft/restbed/ssl_settings.cpp
@@ -77,6 +77,16 @@ namespace restbed
     {
         return m_pimpl->m_single_diffie_hellman_use_enabled;
     }
+
+    bool SSLSettings::has_enabled_server_authentication ( void ) const
+    {
+        return m_pimpl->m_server_authentication_enabled;
+    }
+
+    bool SSLSettings::has_enabled_client_authentication( void ) const
+    {
+        return m_pimpl->m_client_authentication_enabled;
+    }
     
     uint16_t SSLSettings::get_port( void ) const
     {
@@ -121,6 +131,11 @@ namespace restbed
     string SSLSettings::get_certificate_authority_pool( void ) const
     {
         return m_pimpl->m_certificate_authority_pool;
+    }
+    
+    string SSLSettings::get_cipher_suites( void ) const
+    {
+        return m_pimpl->m_cipher_suites;
     }
     
     void SSLSettings::set_port( const uint16_t value )
@@ -192,6 +207,16 @@ namespace restbed
     {
         m_pimpl->m_certificate_authority_pool = String::remove( "file://", value.to_string( ), String::CASE_INSENSITIVE );
     }
+
+    void SSLSettings::set_client_authentication_enabled( const bool value )
+    {
+        m_pimpl->m_client_authentication_enabled = value;
+    }
+    
+    void SSLSettings::set_server_authentication_enabled( const bool value )
+    {
+        m_pimpl->m_server_authentication_enabled = value;
+    }
     
     void SSLSettings::set_passphrase( const string& value )
     {
@@ -211,5 +236,10 @@ namespace restbed
     void SSLSettings::set_temporary_diffie_hellman( const Uri& value )
     {
         m_pimpl->m_temporary_diffie_hellman = String::remove( "file://", value.to_string( ), String::CASE_INSENSITIVE );
+    }
+    
+    void SSLSettings::set_cipher_suites( const std::string ciphersuites )
+    {
+        m_pimpl->m_cipher_suites = ciphersuites;
     }
 }

--- a/source/corvusoft/restbed/ssl_settings.hpp
+++ b/source/corvusoft/restbed/ssl_settings.hpp
@@ -60,6 +60,10 @@ namespace restbed
             bool has_enabled_default_workarounds( void ) const;
             
             bool has_enabled_single_diffie_hellman_use( void ) const;
+
+            bool has_enabled_client_authentication( void ) const;
+	    
+            bool has_enabled_server_authentication( void ) const;
             
             //Getters
             uint16_t get_port( void ) const;
@@ -79,6 +83,8 @@ namespace restbed
             std::string get_temporary_diffie_hellman( void ) const;
             
             std::string get_certificate_authority_pool( void ) const;
+
+	    std::string get_cipher_suites( void ) const;
             
             //Setters
             void set_port( const uint16_t value );
@@ -108,6 +114,10 @@ namespace restbed
             void set_certificate_chain( const Uri& value );
             
             void set_certificate_authority_pool( const Uri& value );
+
+            void set_client_authentication_enabled( const bool value );
+
+            void set_server_authentication_enabled( const bool value );
             
             void set_passphrase( const std::string& value );
             
@@ -116,6 +126,8 @@ namespace restbed
             void set_private_rsa_key( const Uri& value );
             
             void set_temporary_diffie_hellman( const Uri& value );
+	    
+	    void set_cipher_suites( const std::string ciphersuites );
             
             //Operators
             


### PR DESCRIPTION
In this Pull Request, SSL Client authentication is added to the library. Beside, the possibility to explicitly select cipher suites is also added. To allow client authentication to work with BoringSSL (OpenSSL Fork), renegotiation_mode has to be set.

Since asio does not abstract all necessary methods, a dependency to openssl/ssl.h has been introduced.

Note: To test with boringssl, please also apply the change at https://github.com/chriskohlhoff/asio/pull/238 to asio (not yet merged upstream)

About licensing: You can use this changes also with your commercial license.