### PR TITLE
removed wrongly placed `using` from docs

### DIFF
--- a/documentation/STANDARDS.md
+++ b/documentation/STANDARDS.md
@@ -254,7 +254,7 @@ using std::mutex;
 using std::string;
 using std::thread;
 
-using namespace restbed
+namespace restbed
 {
   ...
 }


### PR DESCRIPTION
It's invalid http://cpp.sh/6dawz