### PR TITLE
sock_impl: replace read_until by async_read_until

### DIFF
--- a/source/corvusoft/restbed/detail/socket_impl.cpp
+++ b/source/corvusoft/restbed/detail/socket_impl.cpp
@@ -416,29 +416,47 @@ namespace restbed
             m_timer->cancel( );
             m_timer->expires_from_now( m_timeout );
             m_timer->async_wait( bind( &SocketImpl::connection_timeout_handler, this, shared_from_this( ), _1 ) );
-            
+
             size_t size = 0;
+            auto finished = std::make_shared<bool>(false);
+            auto sharedError = std::make_shared<error_code>();
+            auto sharedSize = std::make_shared<size_t>(0);
+
 #ifdef BUILD_SSL
-            
+
             if ( m_socket not_eq nullptr )
             {
 #endif
-                size = asio::read( *m_socket, *data, asio::transfer_at_least( length ), error );
+                asio::async_read( *m_socket, *data, asio::transfer_at_least( length ),
+                    [ this, finished, sharedSize, sharedError ]( const error_code & error, size_t size ) {
+                        *sharedError = error;
+                        *sharedSize = size;
+                        *finished = true;
+                });
 #ifdef BUILD_SSL
             }
             else
             {
-                size = asio::read( *m_ssl_socket, *data, asio::transfer_at_least( length ), error );
+                asio::async_read( *m_ssl_socket, *data, asio::transfer_at_least( length ),
+                    [ this, finished, sharedSize, sharedError ]( const error_code & error, size_t size ) {
+                        *sharedError = error;
+                        *sharedSize = size;
+                        *finished = true;
+                });
             }
-            
 #endif
+            auto& io_service = m_socket->get_io_service( );
+            while (!*finished)
+                io_service.run_one();
+            error = *sharedError;
+            size = *sharedSize;
             m_timer->cancel( );
-            
+
             if ( error )
             {
                 m_is_open = false;
             }
-            
+
             return size;
         }
         
@@ -547,30 +565,47 @@ namespace restbed
             m_timer->cancel( );
             m_timer->expires_from_now( m_timeout );
             m_timer->async_wait( bind( &SocketImpl::connection_timeout_handler, this, shared_from_this( ), _1 ) );
-            
+
             size_t length = 0;
-            
+            auto finished = std::make_shared<bool>(false);
+            auto sharedError = std::make_shared<error_code>();
+            auto sharedLength = std::make_shared<size_t>(0);
+
 #ifdef BUILD_SSL
-            
+
             if ( m_socket not_eq nullptr )
             {
 #endif
-                length = asio::read_until( *m_socket, *data, delimiter, error );
+                asio::async_read_until( *m_socket, *data, delimiter,
+                    [ this, finished, sharedLength, sharedError ]( const error_code & error, size_t length ) {
+                        *sharedError = error;
+                        *sharedLength = length;
+                        *finished = true;
+                });
 #ifdef BUILD_SSL
             }
             else
             {
-                length = asio::read_until( *m_ssl_socket, *data, delimiter, error );
+                asio::async_read_until( *m_ssl_socket, *data, delimiter,
+                    [ this, finished, sharedLength, sharedError ]( const error_code & error, size_t length ) {
+                        *sharedError = error;
+                        *sharedLength = length;
+                        *finished = true;
+                });
             }
-            
 #endif
+            auto& io_service = m_socket->get_io_service( );
+            while (!*finished)
+                io_service.run_one();
+            error = *sharedError;
+            length = *sharedLength;
             m_timer->cancel( );
-            
+
             if ( error )
             {
                 m_is_open = false;
             }
-            
+
             return length;
         }
         

--- a/test/acceptance/source/connection_timeout/client.cpp
+++ b/test/acceptance/source/connection_timeout/client.cpp
@@ -93,3 +93,64 @@ SCENARIO( "validate connection timeout", "[socket]" )
     service.start( settings );
     worker->join( );
 }
+
+void get_handler_2( const shared_ptr< Session > session )
+{
+        if (session->is_open())
+            session->yield(restbed::OK, "", [ ]( const shared_ptr< Session > session ) {
+                session->sleep_for( seconds( 4 ), [ ]( const shared_ptr< Session > session ) {
+                        REQUIRE (false); // Should not happen, client has quit and server is now down.
+                        session->yield("\n", [](const std::shared_ptr<restbed::Session> /*session*/){
+
+                        });
+                    });
+            });
+}
+
+SCENARIO( "validate connection timeout with async and fetch", "[socket]" )
+{
+    auto resource = make_shared< Resource >( );
+    resource->set_path( "/resource" );
+    resource->set_method_handler( "GET", get_handler_2 );
+    auto settings = std::make_shared<restbed::Settings>();
+    settings->set_default_header("Connection", "keep-alive");
+    std::chrono::milliseconds timeout(std::numeric_limits<int>::max());
+    settings->set_port(1984);
+    settings->set_connection_timeout(timeout); // there is a timeout, but really huge
+    auto service = std::shared_ptr<restbed::Service>(new restbed::Service());
+    service->publish( resource );
+    auto server_thread = std::thread([service, settings]() {
+        service->start( settings );
+    });
+
+    GIVEN( "I try to get the previous handler" )
+    {
+        WHEN( "I perform a request with a connection timeout of '1' seconds" )
+        {
+            auto request = make_shared< Request >( );
+            request->set_port( 1984 );
+            request->set_host( "localhost" );
+            request->set_path( "/resource" );
+
+            auto settingsClient = std::make_shared<restbed::Settings>();
+            settingsClient->set_connection_timeout(std::chrono::seconds(1));
+            Http::async(request,
+                [](const std::shared_ptr<restbed::Request>& req,
+                   const std::shared_ptr<restbed::Response>& reply) {
+                auto code = reply->get_status_code();
+                if (code == 200) {
+                    while (restbed::Http::is_open(req)) {
+                        try {
+                            Http::fetch("\n", reply);
+                        } catch (std::runtime_error& e) {
+                            // Ignore this, operation aborted
+                        }
+                    }
+                }
+            }, settingsClient).get();
+            service->stop();
+            server_thread.join();
+        }
+    }
+}
+


### PR DESCRIPTION
read_until doesn't respond to all signals like cancel(), close(), etc.
So, we should use aync_read_until to handle events in fetch.

cf #271 


Note: Sorry for the clean, my editor replaces some spaces and tabs (If you want, I can disable this behavior).

Note2: Maybe the unit test is a little bit ugly. I did it quickly (Just tried with and without my code)