### PR TITLE
uri: avoid square brackets in authority if querying an ipv6 address

### DIFF
--- a/source/corvusoft/restbed/common.hpp
+++ b/source/corvusoft/restbed/common.hpp
@@ -10,6 +10,8 @@
 #include <sstream>
 #include <algorithm>
 #include <type_traits>
+#include <regex>
+#include <functional>
 
 //Project Includes
 #include <corvusoft/restbed/string.hpp>
@@ -67,6 +69,36 @@ namespace restbed
             static std::string transform( const std::string& value, const std::function< std::string ( const std::string& ) >& transform )
             {
                 return ( transform == nullptr ) ? value : transform( value );
+            }
+
+            static bool is_an_ipv6_address(const std::string& address) {
+                std::string ipv6 =
+                    "(?:"
+                    // For the first 6 fields, match addresses with no jump (::)...
+                    "  (?:                                              (?:[0-9a-f]{1,4}:){6}"
+                    // ...or a jump.
+                    "  |                                             :: (?:[0-9a-f]{1,4}:){5}"
+                    "  | (?:                         [0-9a-f]{1,4})? :: (?:[0-9a-f]{1,4}:){4}"
+                    "  | (?: (?:[0-9a-f]{1,4}:){0,1} [0-9a-f]{1,4})? :: (?:[0-9a-f]{1,4}:){3}"
+                    "  | (?: (?:[0-9a-f]{1,4}:){0,2} [0-9a-f]{1,4})? :: (?:[0-9a-f]{1,4}:){2}"
+                    "  | (?: (?:[0-9a-f]{1,4}:){0,3} [0-9a-f]{1,4})? :: (?:[0-9a-f]{1,4}:)   "
+                    "  | (?: (?:[0-9a-f]{1,4}:){0,4} [0-9a-f]{1,4})? ::                      "
+                    "  )                                                                     "
+                    // Match the base10/16 addresses with no jump (suffix of above).
+                    "  (?: [0-9a-f]{1,4} : [0-9a-f]{1,4}                                     "
+                    "      | (?: (?: 25[0-5] | 2[0-4][0-9] | [01]?[0-9]?[0-9])\\.){3}        "
+                    "        (?: (?: 25[0-5] | 2[0-4][0-9] | [01]?[0-9]?[0-9]))              "
+                    "  )                                                                     "
+                    // Not any above. Check to see if jump is between last 2 fields of addr.
+                    "  | (?: (?:[0-9a-f]{1,4}:){0,5} [0-9a-f]{1,4})? :: [0-9a-f]{1,4}        "
+                    "  | (?: (?:[0-9a-f]{1,4}:){0,6} [0-9a-f]{1,4})? ::                      "
+                    ")";
+                    // End of ipv6 string pattern.
+
+                // Convert readable pattern above into the applicable regex pattern.
+                ipv6.erase( remove_if ( ipv6.begin(), ipv6.end(), ::isspace ) , ipv6.end() );
+                std::regex ipv6_pattern( ipv6 );
+                return regex_search( address, ipv6_pattern );
             }
             
             //Getters

--- a/source/corvusoft/restbed/uri.cpp
+++ b/source/corvusoft/restbed/uri.cpp
@@ -19,6 +19,7 @@
 #endif
 
 //Project Includes
+#include "corvusoft/restbed/common.hpp"
 #include "corvusoft/restbed/uri.hpp"
 #include "corvusoft/restbed/string.hpp"
 #include "corvusoft/restbed/detail/uri_impl.hpp"
@@ -313,7 +314,15 @@ namespace restbed
         
         if ( regex_search( m_pimpl->m_uri, match, pattern ) )
         {
-            return match[ 5 ];
+            std::string authority = match[ 5 ];
+            if ( Common::is_an_ipv6_address(authority) && authority[ 0 ] == '[' )
+            {
+                return authority.substr(1, authority.length() - 2);
+            }
+            else
+            {
+                return authority;
+            }
         }
         
         return String::empty;


### PR DESCRIPTION
tcp::resolver does not resolve an ipv6 address between square
brackets. So we need to remove it before call resolver.async_resolve
or it will fails.

fix #290 