### PR TITLE
tests: fix include path for Catch

### DIFF
--- a/cmake/modules/Findcatch.cmake
+++ b/cmake/modules/Findcatch.cmake
@@ -1,6 +1,6 @@
 # Copyright 2013-2017, Corvusoft Ltd, All Rights Reserved.
 
-find_path( catch_INCLUDE catch.hpp HINTS "${PROJECT_SOURCE_DIR}/dependency/catch/include" "/usr/include" "/usr/local/include" "/opt/local/include" )
+find_path( catch_INCLUDE catch.hpp HINTS "${PROJECT_SOURCE_DIR}/dependency/catch/include" "/usr/include" "/usr/include/catch" "/usr/include/catch2" "/usr/local/include" "/usr/local/include/catch" "/usr/local/include/catch2" "/opt/local/include" "/opt/local/include/catch" "/opt/local/include/catch2" )
 
 if ( catch_INCLUDE )
     set( CATCH_FOUND TRUE )


### PR DESCRIPTION
Recent versions of Catch2 are in /usr/include/catch or
/usr/include/catch2, see the notice here:

  https://github.com/catchorg/Catch2/releases/tag/v2.2.0

This patch tells CMake to look in all possible include directories.