### PR TITLE
cmake: Auto-detect Catch dependency to decide whether to enable tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,6 @@ set( VERSION "${restbed_VERSION}" )
 #
 option( BUILD_SHARED   "Build shared library."              OFF )
 option( BUILD_EXAMPLES "Build examples applications."       OFF )
-option( BUILD_TESTS    "Build all available test suites."   OFF )
 option( BUILD_SSL      "Build secure socket layer support."  ON )
 
 #
@@ -37,6 +36,13 @@ include_directories( SYSTEM ${kashmir_INCLUDE} )
 if ( BUILD_SSL )
     find_package( openssl REQUIRED )
     include_directories( SYSTEM ${ssl_INCLUDE} )
+endif ( )
+
+find_package( catch )
+if ( CATCH_FOUND )
+    option( BUILD_TESTS    "Build all available test suites."   ON)
+else ( )
+    option( BUILD_TESTS    "Build all available test suites."  OFF)
 endif ( )
 
 #

--- a/cmake/modules/Findcatch.cmake
+++ b/cmake/modules/Findcatch.cmake
@@ -2,10 +2,5 @@
 
 find_path( catch_INCLUDE catch.hpp HINTS "${PROJECT_SOURCE_DIR}/dependency/catch/include" "/usr/include" "/usr/include/catch" "/usr/include/catch2" "/usr/local/include" "/usr/local/include/catch" "/usr/local/include/catch2" "/opt/local/include" "/opt/local/include/catch" "/opt/local/include/catch2" )
 
-if ( catch_INCLUDE )
-    set( CATCH_FOUND TRUE )
-
-    message( STATUS "${Green}Found Catch include at: ${catch_INCLUDE}${Reset}" )
-else ( )
-    message( FATAL_ERROR "${Red}Failed to locate Catch dependency.${Reset}" )
-endif ( )
+include(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(catch DEFAULT_MSG catch_INCLUDE)


### PR DESCRIPTION
This automatically enables or disables tests, depending on whether Catch
is found on the system.

Of course, it is still possible to force building tests:

* `-DBUILD_TESTS=OFF` will disable tests even if Catch is found
* `-DBUILD_TESTS=ON` will enable tests even if Catch is not found (mostly useful because it causes cmake to fail early)