### PR TITLE
Cookie parsing and "path parameters"

### DIFF
--- a/source/corvusoft/restbed/detail/request_impl.hpp
+++ b/source/corvusoft/restbed/detail/request_impl.hpp
@@ -56,6 +56,8 @@ namespace restbed
             
             std::multimap< std::string, std::string > m_headers { };
             
+            std::map< std::string, std::string > m_cookie_parameters { };
+            
             std::map< std::string, std::string > m_path_parameters { };
             
             std::multimap< std::string, std::string > m_query_parameters { };

--- a/source/corvusoft/restbed/detail/resource_impl.hpp
+++ b/source/corvusoft/restbed/detail/resource_impl.hpp
@@ -6,7 +6,6 @@
 
 //System Includes
 #include <map>
-#include <set>
 #include <string>
 #include <vector>
 #include <functional>
@@ -33,7 +32,7 @@ namespace restbed
         
         struct ResourceImpl
         {
-            std::set< std::string > m_paths { };
+            std::vector< std::string > m_paths { };
             
             std::set< std::string > m_methods { };
             

--- a/source/corvusoft/restbed/detail/service_impl.cpp
+++ b/source/corvusoft/restbed/detail/service_impl.cpp
@@ -757,6 +757,30 @@ namespace restbed
                 }
                 
                 headers.insert( make_pair( matches[ 1 ].str( ), matches[ 2 ].str( ) ) );
+
+                if(matches[1].str() == "Cookie" || matches[1].str() == "Set-Cookie"){
+                    std::string cookie_header = matches[2].str();
+                    smatch cookiev_matches;
+                    static const regex cookiev_pattern( "([\\s]*<?([^;\\s>]+)>?[\\s]*=[\\s]*<?([^;>]+)>?[\\s]*;?)|[\\s]*<?([^;\\s>]+)>?[\\s]*;?" );
+                    string::const_iterator searchStart( cookie_header.cbegin() );
+                    
+                    regex_match( cookie_header, cookiev_matches, cookiev_pattern );
+
+                    while ( regex_search( searchStart, cookie_header.cend(), cookiev_matches, cookiev_pattern ) )
+                    {
+                        if(cookiev_matches[4].str().empty()){
+                            session->m_pimpl->m_request->m_pimpl->m_cookie_parameters.insert(
+                                make_pair( cookiev_matches[2].str(), cookiev_matches[3].str() )
+                            );
+                        }
+                        else{
+                            session->m_pimpl->m_request->m_pimpl->m_cookie_parameters.insert(
+                                make_pair( cookiev_matches[4].str(), "yes" )
+                            );
+                        }
+                        searchStart += cookiev_matches.position() + cookiev_matches.length();
+                    }
+                }
             }
             
             return headers;

--- a/source/corvusoft/restbed/detail/service_impl.cpp
+++ b/source/corvusoft/restbed/detail/service_impl.cpp
@@ -374,7 +374,7 @@ namespace restbed
             }
         }
         
-        bool ServiceImpl::has_unique_paths( const set< string >& paths ) const
+        bool ServiceImpl::has_unique_paths( const vector< string >& paths ) const
         {
             if ( paths.empty( ) )
             {

--- a/source/corvusoft/restbed/detail/service_impl.cpp
+++ b/source/corvusoft/restbed/detail/service_impl.cpp
@@ -37,7 +37,7 @@
 //External Includes
 
 //System Namespaces
-using std::set;
+using std::vector;
 using std::map;
 using std::free;
 using std::pair;

--- a/source/corvusoft/restbed/detail/service_impl.cpp
+++ b/source/corvusoft/restbed/detail/service_impl.cpp
@@ -79,6 +79,7 @@ namespace restbed
 {
     namespace detail
     {
+        std::map<std::string, int> ServiceImpl::m_route_order = { };
         ServiceImpl::ServiceImpl( void ) : m_uptime( steady_clock::time_point::min( ) ),
             m_logger( nullptr ),
             m_supported_methods( ),

--- a/source/corvusoft/restbed/detail/service_impl.cpp
+++ b/source/corvusoft/restbed/detail/service_impl.cpp
@@ -559,7 +559,7 @@ namespace restbed
         void ServiceImpl::extract_path_parameters( const string& sanitised_path, const shared_ptr< const Request >& request ) const
         {
             smatch matches;
-            static const regex pattern( "^\\{([a-zA-Z0-9_\\-]+): ?.*\\}$" );
+            static const regex pattern( "^\\{([a-zA-Z0-9_\\-]+): ?(.*)\\}$" );
             
             const auto folders = String::split( request->get_path( ), '/' );
             const auto declarations = String::split( m_settings->get_root( ) + "/" + m_resource_paths.at( sanitised_path ), '/' );

--- a/source/corvusoft/restbed/detail/service_impl.hpp
+++ b/source/corvusoft/restbed/detail/service_impl.hpp
@@ -56,6 +56,15 @@ namespace restbed
                 //Friends
                 
                 //Definitions
+                int m_last_route_pos;
+
+                static std::map<std::string, int> m_route_order;
+
+                struct SortByInsertion {
+                    bool operator() (const std::string& lv, const std::string& rv) const {
+                        return m_route_order[lv] < m_route_order[rv] ? true : false;
+                    }
+                };
                 
                 //Constructors
                 ServiceImpl( void );
@@ -153,9 +162,9 @@ namespace restbed
 #endif
                 std::shared_ptr< asio::ip::tcp::acceptor > m_acceptor;
                 
-                std::map< std::string, std::string > m_resource_paths;
+                std::map< std::string, std::string, SortByInsertion > m_resource_paths;
                 
-                std::map< std::string, std::shared_ptr< const Resource > > m_resource_routes;
+                std::map< std::string, std::shared_ptr< const Resource >, SortByInsertion > m_resource_routes;
                 
                 std::function< void ( void ) > m_ready_handler;
                 

--- a/source/corvusoft/restbed/detail/service_impl.hpp
+++ b/source/corvusoft/restbed/detail/service_impl.hpp
@@ -118,7 +118,7 @@ namespace restbed
                 
                 static const std::map< std::string, std::string > parse_request_line( std::istream& stream );
                 
-                static const std::multimap< std::string, std::string > parse_request_headers( std::istream& stream );
+                static const std::multimap< std::string, std::string > parse_request_headers( std::istream& stream, const std::shared_ptr< Session > session );
                 
                 void parse_request( const std::error_code& error, std::size_t length, const std::shared_ptr< Session > session ) const;
                 

--- a/source/corvusoft/restbed/detail/service_impl.hpp
+++ b/source/corvusoft/restbed/detail/service_impl.hpp
@@ -90,7 +90,7 @@ namespace restbed
                 
                 void not_found( const std::shared_ptr< Session > session ) const;
                 
-                bool has_unique_paths( const std::set< std::string >& paths ) const;
+                bool has_unique_paths( const std::vector< std::string >& paths ) const;
                 
                 void log( const Logger::Level level, const std::string& message ) const;
                 

--- a/source/corvusoft/restbed/request.cpp
+++ b/source/corvusoft/restbed/request.cpp
@@ -200,6 +200,75 @@ namespace restbed
         return Common::get_parameters( name, m_pimpl->m_headers );
     }
     
+    float Request::get_cookie_parameter( const string& name, const float default_value ) const
+    {
+        float parameter = 0;
+        
+        try
+        {
+            parameter = stof( get_cookie_parameter( name ) );
+        }
+        catch ( const out_of_range )
+        {
+            parameter = default_value;
+        }
+        catch ( const invalid_argument )
+        {
+            parameter = default_value;
+        }
+        
+        return parameter;
+    }
+    
+    double Request::get_cookie_parameter( const string& name, const double default_value ) const
+    {
+        double parameter = 0;
+        
+        try
+        {
+            parameter = stod( get_cookie_parameter( name ) );
+        }
+        catch ( const out_of_range )
+        {
+            parameter = default_value;
+        }
+        catch ( const invalid_argument )
+        {
+            parameter = default_value;
+        }
+        
+        return parameter;
+    }
+    
+    string Request::get_cookie_parameter( const string& name, const string& default_value ) const
+    {
+        if ( name.empty( ) )
+        {
+            return default_value;
+        }
+        
+        const auto parameters = Common::get_parameters( name, m_pimpl->m_cookie_parameters );
+        return ( parameters.empty( ) ) ? default_value : parameters.begin( )->second;
+    }
+
+    string Request::get_cookie_parameter( const string& name, const function< string ( const string& ) >& transform ) const
+    {
+        if ( name.empty( ) )
+        {
+            return String::empty;
+        }
+        
+        const auto parameters = Common::get_parameters( name, m_pimpl->m_cookie_parameters );
+        const auto value = ( parameters.empty( ) ) ? String::empty : parameters.begin( )->second;
+        
+        return Common::transform( value, transform );
+    }
+
+    map< string, string > Request::get_cookie_parameters( const string& name ) const
+    {
+        return Common::get_parameters( name, m_pimpl->m_cookie_parameters );
+    }
+    
     float Request::get_query_parameter( const string& name, const float default_value ) const
     {
         float parameter = 0;

--- a/source/corvusoft/restbed/request.hpp
+++ b/source/corvusoft/restbed/request.hpp
@@ -97,6 +97,23 @@ namespace restbed
             }
             
             std::multimap< std::string, std::string > get_headers( const std::string& name = "" ) const;
+        
+            float get_cookie_parameter( const std::string& name, const float default_value ) const;
+            
+            double get_cookie_parameter( const std::string& name, const double default_value ) const;
+            
+            std::string get_cookie_parameter( const std::string& name, const std::string& default_value = "" ) const;
+            
+            std::string get_cookie_parameter( const std::string& name, const std::function< std::string ( const std::string& ) >& transform ) const;
+            
+            template< typename Type, typename std::enable_if< std::is_arithmetic< Type >::value, Type >::type = 0 >
+            Type get_cookie_parameter( const std::string& name, const Type default_value ) const
+            {
+                return Common::parse_parameter( get_cookie_parameter( name ), default_value );
+            }
+            
+            std::map< std::string, std::string > get_cookie_parameters( const std::string& name = "" ) const;
+
             
             float get_query_parameter( const std::string& name, const float default_value ) const;
             

--- a/source/corvusoft/restbed/resource.cpp
+++ b/source/corvusoft/restbed/resource.cpp
@@ -21,7 +21,7 @@
 //External Includes
 
 //System Namespaces
-using std::set;
+using std::vector;
 using std::string;
 using std::multimap;
 using std::function;
@@ -74,7 +74,7 @@ namespace restbed
         m_pimpl->m_paths = { value };
     }
     
-    void Resource::set_paths( const set< string >& values )
+    void Resource::set_paths( const vector< string >& values )
     {
         m_pimpl->m_paths = values;
     }

--- a/source/corvusoft/restbed/resource.hpp
+++ b/source/corvusoft/restbed/resource.hpp
@@ -6,7 +6,7 @@
 
 //System Includes
 #include <map>
-#include <set>
+#include <vector>
 #include <string>
 #include <functional>
 
@@ -56,7 +56,7 @@ namespace restbed
             //Setters
             void set_path( const std::string& value );
             
-            void set_paths( const std::set< std::string >& values );
+            void set_paths( const std::vector< std::string >& values );
             
             void set_default_header( const std::string& name, const std::string& value );
             

--- a/source/corvusoft/restbed/service.cpp
+++ b/source/corvusoft/restbed/service.cpp
@@ -265,6 +265,7 @@ namespace restbed
         {
             const string sanitised_path = m_pimpl->sanitise_path( path );
             
+            m_pimpl->m_route_order[ sanitised_path ] = ++m_pimpl->m_last_route_pos;
             m_pimpl->m_resource_paths[ sanitised_path ] = path;
             m_pimpl->m_resource_routes[ sanitised_path ] = resource;
         }

--- a/source/corvusoft/restbed/service.cpp
+++ b/source/corvusoft/restbed/service.cpp
@@ -288,15 +288,15 @@ namespace restbed
         
         auto paths = resource->m_pimpl->m_paths;
         
-        for ( auto i = paths.begin(); i != paths.end(); i++ ) {
+        for ( auto& path : paths )
         {
-            if ( m_pimpl->m_resource_routes.erase( i ) )
+            if ( m_pimpl->m_resource_routes.erase( path ) )
             {
-                m_pimpl->log( Logger::INFO, String::format( "Suppressed resource route '%s'.", (*i).data( ) ) );
+                m_pimpl->log( Logger::INFO, String::format( "Suppressed resource route '%s'.", path.data( ) ) );
             }
             else
             {
-                m_pimpl->log( Logger::WARNING, String::format( "Failed to suppress resource route '%s'; Not Found!", (*i).data( ) ) );
+                m_pimpl->log( Logger::WARNING, String::format( "Failed to suppress resource route '%s'; Not Found!", path.data( ) ) );
             }
         }
     }

--- a/source/corvusoft/restbed/service.cpp
+++ b/source/corvusoft/restbed/service.cpp
@@ -285,15 +285,17 @@ namespace restbed
             return;
         }
         
-        for ( const auto& path : resource->m_pimpl->m_paths )
+        auto paths = resource->m_pimpl->m_paths;
+        
+        for ( auto i = paths.begin(); i != paths.end(); i++ ) {
         {
-            if ( m_pimpl->m_resource_routes.erase( path ) )
+            if ( m_pimpl->m_resource_routes.erase( i ) )
             {
-                m_pimpl->log( Logger::INFO, String::format( "Suppressed resource route '%s'.", path.data( ) ) );
+                m_pimpl->log( Logger::INFO, String::format( "Suppressed resource route '%s'.", (*i).data( ) ) );
             }
             else
             {
-                m_pimpl->log( Logger::WARNING, String::format( "Failed to suppress resource route '%s'; Not Found!", path.data( ) ) );
+                m_pimpl->log( Logger::WARNING, String::format( "Failed to suppress resource route '%s'; Not Found!", (*i).data( ) ) );
             }
         }
     }


### PR DESCRIPTION
## Full paths
This will come in handy in cases where a developer wants to serve static files from a folder (css, etc.).

Here is the syntax:
`static_resource->set_path( "/static/{filepath: TO_END}" );`
`static_resource->set_paths( {"/{filepath: TO_END}", "/static/{filepath: TO_END}"} );`

Only 1 "TO_END" parameter can be used per path

## Cookies
`request->get_cookie_parameter("my-value");`
`request->get_cookie_parameters();`