### PR TITLE
Fix link to examples in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ int main( const int, const char** )
 }
 ```
 
-More in-depth examples can be found [here](https://github.com/corvusoft/restbed/tree/master/example). To see Restbed used in anger, please visit Corvusoft's [RestQ](https://github.com/corvusoft/restq) project.
+More in-depth examples can be found [here](https://github.com/Corvusoft/restbed/tree/master/documentation/example). To see Restbed used in anger, please visit Corvusoft's [RestQ](https://github.com/corvusoft/restq) project.
 
 License
 -------


### PR DESCRIPTION
First thing I wanted to find were examples, I didn't realise that the features section *were* examples. Followed this link to see a 404. Fixed now!