### PR TITLE
fix get_io_service null reference in case of ssl socket usage

### DIFF
--- a/source/corvusoft/restbed/detail/socket_impl.hpp
+++ b/source/corvusoft/restbed/detail/socket_impl.hpp
@@ -156,7 +156,9 @@ namespace restbed
                 std::shared_ptr< Logger > m_logger;
                 
                 std::chrono::milliseconds m_timeout;
-                
+
+                asio::io_context &m_io_service;
+
                 std::shared_ptr< asio::steady_timer > m_timer;
                 
                 std::shared_ptr< asio::io_service::strand > m_strand;
@@ -164,7 +166,7 @@ namespace restbed
                 std::shared_ptr< asio::ip::tcp::resolver > m_resolver;
                 
                 std::shared_ptr< asio::ip::tcp::socket > m_socket;
-                
+
 #ifdef BUILD_SSL
                 std::shared_ptr< asio::ssl::stream< asio::ip::tcp::socket > > m_ssl_socket;
 #endif


### PR DESCRIPTION
refactor `io_service` as separated class property due to frequently usage:
`socket_impl.cpp:448` and `socket_impl.cpp:597` gets `io_stream` from `m_soket` instead of `m_ssl_socket`