### PR TITLE
settings: add keep-alive options

### DIFF
--- a/source/corvusoft/restbed/detail/service_impl.cpp
+++ b/source/corvusoft/restbed/detail/service_impl.cpp
@@ -291,6 +291,11 @@ namespace restbed
                     
                     auto connection = make_shared< SocketImpl >( socket, m_logger );
                     connection->set_timeout( m_settings->get_connection_timeout( ) );
+                    if (m_settings->get_keep_alive()) {
+                        connection->set_keep_alive( m_settings->get_keep_alive_start(),
+                            m_settings->get_keep_alive_interval(),
+                            m_settings->get_keep_alive_cnt());
+                    }
                     
                     m_session_manager->create( [ this, connection ]( const shared_ptr< Session > session )
                     {
@@ -527,6 +532,11 @@ namespace restbed
             {
                 auto connection = make_shared< SocketImpl >( socket, m_logger );
                 connection->set_timeout( m_settings->get_connection_timeout( ) );
+                if (m_settings->get_keep_alive()) {
+                    connection->set_keep_alive( m_settings->get_keep_alive_start(),
+                        m_settings->get_keep_alive_interval(),
+                        m_settings->get_keep_alive_cnt());
+                }
                 
                 m_session_manager->create( [ this, connection ]( const shared_ptr< Session > session )
                 {

--- a/source/corvusoft/restbed/detail/settings_impl.hpp
+++ b/source/corvusoft/restbed/detail/settings_impl.hpp
@@ -43,7 +43,15 @@ namespace restbed
             std::string m_bind_address = "";
             
             bool m_case_insensitive_uris = true;
-            
+
+            bool m_keep_alive = true;
+
+            uint32_t m_keep_alive_start = 900;
+
+            uint32_t m_keep_alive_interval = 900;
+
+            uint32_t m_keep_alive_cnt = 3;
+
             std::map< std::string, std::string > m_properties { };
             
             std::shared_ptr< const SSLSettings > m_ssl_settings = nullptr;

--- a/source/corvusoft/restbed/detail/socket_impl.hpp
+++ b/source/corvusoft/restbed/detail/socket_impl.hpp
@@ -89,6 +89,8 @@ namespace restbed
                 
                 //Setters
                 void set_timeout( const std::chrono::milliseconds& value );
+
+                void set_keep_alive( const uint32_t start, const uint32_t interval, const uint32_t cnt);
                 
                 //Operators
                 

--- a/source/corvusoft/restbed/settings.cpp
+++ b/source/corvusoft/restbed/settings.cpp
@@ -62,15 +62,35 @@ namespace restbed
     {
         return m_pimpl->m_bind_address;
     }
-    
+
     bool Settings::get_case_insensitive_uris( void ) const
     {
         return m_pimpl->m_case_insensitive_uris;
     }
-    
+
     milliseconds Settings::get_connection_timeout( void ) const
     {
         return m_pimpl->m_connection_timeout;
+    }
+
+    bool Settings::get_keep_alive ( void ) const
+    {
+        return m_pimpl->m_keep_alive;
+    }
+
+    uint32_t Settings::get_keep_alive_start ( void ) const
+    {
+        return m_pimpl->m_keep_alive_start;
+    }
+
+    uint32_t Settings::get_keep_alive_interval ( void ) const
+    {
+        return m_pimpl->m_keep_alive_interval;
+    }
+
+    uint32_t Settings::get_keep_alive_cnt ( void ) const
+    {
+        return m_pimpl->m_keep_alive_cnt;
     }
     
     string Settings::get_status_message( const int code ) const
@@ -142,7 +162,27 @@ namespace restbed
     {
         m_pimpl->m_connection_timeout = value;
     }
-    
+
+    void Settings::set_keep_alive( bool value )
+    {
+        m_pimpl->m_keep_alive = value;
+    }
+
+    void Settings::set_keep_alive_start( const uint32_t value )
+    {
+        m_pimpl->m_keep_alive_start = value;
+    }
+
+    void Settings::set_keep_alive_interval( const uint32_t value )
+    {
+        m_pimpl->m_keep_alive_interval = value;
+    }
+
+    void Settings::set_keep_alive_cnt( const uint32_t value )
+    {
+        m_pimpl->m_keep_alive_cnt = value;
+    }
+
     void Settings::set_status_message( const int code, const string& message )
     {
         m_pimpl->m_status_messages[ code ] = message;

--- a/source/corvusoft/restbed/settings.hpp
+++ b/source/corvusoft/restbed/settings.hpp
@@ -59,6 +59,14 @@ namespace restbed
             bool get_case_insensitive_uris( void ) const;
             
             std::chrono::milliseconds get_connection_timeout( void ) const;
+
+            bool get_keep_alive ( void ) const;
+
+            uint32_t get_keep_alive_start ( void ) const;
+
+            uint32_t get_keep_alive_interval ( void ) const;
+
+            uint32_t get_keep_alive_cnt ( void ) const;
             
             std::string get_status_message( const int code ) const;
             
@@ -88,6 +96,14 @@ namespace restbed
             void set_connection_timeout( const std::chrono::seconds& value );
             
             void set_connection_timeout( const std::chrono::milliseconds& value );
+
+            void set_keep_alive ( bool value );
+
+            void set_keep_alive_start ( const uint32_t value );
+
+            void set_keep_alive_interval ( const uint32_t value );
+
+            void set_keep_alive_cnt ( const uint32_t value );
             
             void set_status_message( const int code, const std::string& message );
             


### PR DESCRIPTION
In a server/client architecture, the client can loose its connectivity.
In this configuration, if the socket is not used, it will remains opened
unti the server try to use it. In some cases, there is nothing to send to
the client. The server should be able to send KEEP-ALIVE packets to
detect unreachable clients. This patch adds some settings to configure
this keep alive mechanism.

Issue: #324