### PR TITLE
Fix: Memory leak in test cases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,8 @@ Thumbs.db
 Desktop.ini
 $RECYCLE.BIN/
 *.lnk
+
+# IDE Related
+
+.vscode/
+.idea/

--- a/test/unit/source/resource_suite.cpp
+++ b/test/unit/source/resource_suite.cpp
@@ -16,7 +16,7 @@ using restbed::Resource;
 
 TEST_CASE( "confirm default constructor throws no exceptions", "[resource]" )
 {
-    REQUIRE_NOTHROW( new Resource );
+    REQUIRE_NOTHROW( std::unique_ptr<Resource> (new Resource) );
 }
 
 TEST_CASE( "confirm default destructor throws no exceptions", "[resource]" )

--- a/test/unit/source/service_suite.cpp
+++ b/test/unit/source/service_suite.cpp
@@ -18,7 +18,7 @@ using restbed::Service;
 
 TEST_CASE( "confirm default constructor throws no exceptions", "[service]" )
 {
-    REQUIRE_NOTHROW( new Service );
+    REQUIRE_NOTHROW( std::unique_ptr<Service> (new Service) );
 }
 
 TEST_CASE( "confirm default destructor throws no exceptions", "[service]" )


### PR DESCRIPTION
When running Valgrind in test cases, I've found that two cases where leaking memory. It's not a big deal. But this could help avoiding finding fake leaks in library code itself. This is a suggested workaround to avoid this memory leak. In this case I use std::unique_ptr because:

> std::unique_ptr are designed to keep ownership of an allocated object and destroy the object when the
> unique pointer gets himself destroyed.

as [this thread](https://stackoverflow.com/questions/46383097/how-to-delete-smart-pointer-to-dynamically-allocated-object) in stack overflow explains.