### PR TITLE
Fix request header regex

### DIFF
--- a/source/corvusoft/restbed/detail/service_impl.cpp
+++ b/source/corvusoft/restbed/detail/service_impl.cpp
@@ -715,7 +715,7 @@ namespace restbed
             smatch matches;
             string data = "";
             multimap< string, string > headers;
-            static const regex pattern( "^([^:.]*): *(.*)\\s*$" );
+            static const regex pattern( "^([^:]*): *(.*)\\s*$" );
             
             while ( getline( stream, data ) and data not_eq "\r" )
             {


### PR DESCRIPTION
Several [new HTTP headers](http://www.nt.uni-saarland.de/fileadmin/file_uploads/theses/bachelor/bachelor-thesis-final_01.pdf#subsection.2.7.3) are introduced by the DLNA to specify transfer parameters.