### PR TITLE
Fix String::format use of va_list

### DIFF
--- a/source/corvusoft/restbed/string.cpp
+++ b/source/corvusoft/restbed/string.cpp
@@ -63,15 +63,17 @@ namespace restbed
         va_start( arguments, format );
         
         string formatted = "";
-        string::size_type length = 1024;
+        string::size_type length = FORMAT_BUFFER_INITIAL_LENGTH;
         string::size_type required_length = String::format( formatted, length, format, arguments );
+        
+        va_end( arguments );
         
         if ( required_length > length )
         {
+            va_start( arguments, format );
             String::format( formatted, required_length, format, arguments );
+            va_end( arguments );
         }
-        
-        va_end( arguments );
         
         return formatted;
     }

--- a/source/corvusoft/restbed/string.hpp
+++ b/source/corvusoft/restbed/string.hpp
@@ -37,6 +37,8 @@ namespace restbed
                 CASE_INSENSITIVE = 1
             };
             
+            static const size_t FORMAT_BUFFER_INITIAL_LENGTH = 1024;
+            
             //Constructors
             
             //Functionality

--- a/source/corvusoft/restbed/string.hpp
+++ b/source/corvusoft/restbed/string.hpp
@@ -37,7 +37,7 @@ namespace restbed
                 CASE_INSENSITIVE = 1
             };
             
-            static const size_t FORMAT_BUFFER_INITIAL_LENGTH = 1024;
+            static const size_t FORMAT_BUFFER_INITIAL_LENGTH = 2048;
             
             //Constructors
             

--- a/test/unit/source/string_suite.cpp
+++ b/test/unit/source/string_suite.cpp
@@ -74,6 +74,26 @@ TEST_CASE( "format with empty", "[string]" )
     REQUIRE( String::format( "" ) == "" );
 }
 
+TEST_CASE( "format with string length equal to initial buffer length", "[string]" )
+{
+    size_t length = String::FORMAT_BUFFER_INITIAL_LENGTH;
+    string str( length, ' ' );
+    for ( size_t i = 0; i < length; i++ ) {
+        str[ i ] = ( i % 95 ) + 32;
+    }
+    REQUIRE( String::format( "%s", str.c_str() ) == str );
+}
+
+TEST_CASE( "format with string length equal to initial buffer length + 1", "[string]" )
+{
+    size_t length = String::FORMAT_BUFFER_INITIAL_LENGTH + 1;
+    string str( length, ' ' );
+    for ( size_t i = 0; i < length; i++ ) {
+        str[ i ] = ( i % 95 ) + 32;
+    }
+    REQUIRE( String::format( "%s", str.c_str() ) == str );
+}
+
 TEST_CASE( "split", "[string]" )
 {
     REQUIRE( String::split( "Corvusoft Solutions", ' ' ) == vector< string >( { "Corvusoft", "Solutions" } ) );


### PR DESCRIPTION
**Problem:** `String::format(const char*, ...)` calls `String::format` no. 2 twice if the allocated length isn't sufficient the first time.  The problem is that in the first call to `String::format` no. 2, `vsnprintf` exhausts the `va_list`, so the `va_list` is no longer valid for the second call, and so the formatted string contains invalid data.

**Fix:**  The `va_list` is reinitialized for the second call to `String::format` no. 2.  Added tests that expose the problem and verify the solution.

**Also:**  I bumped the initial buffer length for `String::format` from `1024` to `2048`.
