### PR TITLE
Build and portability fixes for 4.7 release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,9 +7,9 @@ message( "Copyright 2013-2018, Corvusoft Ltd, All Rights Reserved." )
 # Build Options
 #
 option( BUILD_SSL      "Build secure socket layer support."  ON )
-option( BUILD_TESTS    "Build unit tests."  ON )
 option( BUILD_STATIC   "Build static library."  ON )
 option( BUILD_SHARED   "Build shared library."  OFF )
+# See also BUILD_TESTS build option below.
 
 #
 # Configuration
@@ -50,6 +50,14 @@ if ( BUILD_SSL )
 endif ( )
 
 include_directories( ${INCLUDE_DIR} SYSTEM ${asio_INCLUDE} ${kashmir_INCLUDE} ${ssl_INCLUDE} )
+
+# Enable tests by default if Catch2 is found (can still be overriden)
+find_package( catch )
+if ( CATCH_FOUND )
+    option( BUILD_TESTS    "Build unit tests."   ON)
+else ( )
+    option( BUILD_TESTS    "Build unit tests."   OFF)
+endif ( )
 
 #
 # Build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,7 @@ if ( BUILD_SSL )
     find_package( openssl REQUIRED )
 endif ( )
 
-include_directories( ${INCLUDE_DIR} SYSTEM ${asio_INCLUDE} ${kashmir_INCLUDE} ${ssl_INCLUDE} )
+include_directories( ${INCLUDE_DIR} SYSTEM ${asio_INCLUDE} ${ssl_INCLUDE} )
 
 # Enable tests by default if Catch2 is found (can still be overriden)
 find_package( catch )

--- a/README.md
+++ b/README.md
@@ -98,8 +98,10 @@ Support
 
 Please contact sales@corvusoft.co.uk, for support and licensing options including bespoke software development, testing, design consultation, training, mentoring and code review.
 
-Build
------
+Please submit all enhancements, proposals, and defects via the [issue](http://github.com/corvusoft/restbed/issues) tracker; Alternatively ask a question on [StackOverflow](http://stackoverflow.com/questions/ask) tagged [#restbed](http://stackoverflow.com/questions/tagged/restbed).
+
+Build statically
+----------------
 
 ```bash
 git clone --recursive https://github.com/corvusoft/restbed.git
@@ -112,7 +114,38 @@ make test
 
 You will now find all required components installed in the distribution folder.
 
-Please submit all enhancements, proposals, and defects via the [issue](http://github.com/corvusoft/restbed/issues) tracker; Alternatively ask a question on [StackOverflow](http://stackoverflow.com/questions/ask) tagged [#restbed](http://stackoverflow.com/questions/tagged/restbed).
+Build with external libraries
+-----------------------------
+
+If you build with external libraries (openssl, asio), you probably want to only use shared libraries:
+
+```bash
+git clone https://github.com/corvusoft/restbed.git
+mkdir restbed/build
+cd restbed/build
+cmake -DBUILD_STATIC=OFF -DBUILD_SHARED=ON ..
+make install
+make test
+```
+
+Building unit tests
+-------------------
+
+By default, the build system detects if [catch2](https://github.com/catchorg/Catch2/) is installed and enables tests in this case.
+
+You can also force building tests or not:
+
+```bash
+# Disable tests even if catch2 is found.
+cmake -DBUILD_TESTS=OFF ..
+
+# Try to enable tests even if catch2 is not found.
+# This is useful to make the build fail: this way, you know that something is wrong with catch2 detection.
+cmake -DBUILD_TESTS=ON ..
+```
+
+Other build instructions
+------------------------
 
 For Microsoft Visual Studio instructions please see feature [#17](https://github.com/Corvusoft/restbed/issues/17).
 

--- a/cmake/Findcatch.cmake
+++ b/cmake/Findcatch.cmake
@@ -1,9 +1,4 @@
 find_path( catch_INCLUDE catch.hpp HINTS "${PROJECT_SOURCE_DIR}/dependency/catch/single_include/catch2" "/usr/include/catch2/single_include" "/usr/include/catch2" "/usr/local/include/catch2/single_include" "/usr/local/include/catch2" "/opt/local/include/catch2/single_include" "/opt/local/include/catch2" )
 
-if ( catch_INCLUDE )
-    set( CATCH_FOUND TRUE )
-
-    message( STATUS "Found Catch include at: ${catch_INCLUDE}" )
-else ( )
-    message( FATAL_ERROR "Failed to locate Catch dependency." )
-endif ( )
+include(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(catch DEFAULT_MSG catch_INCLUDE)

--- a/cmake/Findcatch.cmake
+++ b/cmake/Findcatch.cmake
@@ -1,4 +1,4 @@
-find_path( catch_INCLUDE catch.hpp HINTS "${PROJECT_SOURCE_DIR}/dependency/catch/single_include/catch2" "/usr/include/catch2/single_include" "/usr/local/include/catch2/single_include" "/opt/local/include/catch2/single_include" )
+find_path( catch_INCLUDE catch.hpp HINTS "${PROJECT_SOURCE_DIR}/dependency/catch/single_include/catch2" "/usr/include/catch2/single_include" "/usr/include/catch2" "/usr/local/include/catch2/single_include" "/usr/local/include/catch2" "/opt/local/include/catch2/single_include" "/opt/local/include/catch2" )
 
 if ( catch_INCLUDE )
     set( CATCH_FOUND TRUE )

--- a/cmake/Findopenssl.cmake
+++ b/cmake/Findopenssl.cmake
@@ -6,7 +6,7 @@ find_library( crypto_LIBRARY_SHARED libcrypto.so libcrypto.dylib libeay32.dll HI
 
 find_path( ssl_INCLUDE openssl/ssl.h HINTS "${PROJECT_SOURCE_DIR}/dependency/openssl/inc32" "${PROJECT_SOURCE_DIR}/dependency/openssl/include" "/usr/local/opt/openssl/include" "/usr/include" "/usr/local/include" "/opt/local/include" )
 
-if ( ssl_LIBRARY_STATIC AND ssl_LIBRARY_SHARED AND crypto_LIBRARY_STATIC AND crypto_LIBRARY_SHARED )
+if ( (ssl_LIBRARY_STATIC AND crypto_LIBRARY_STATIC) OR (ssl_LIBRARY_SHARED AND crypto_LIBRARY_SHARED) )
     set( OPENSSL_FOUND TRUE )
     add_definitions( -DBUILD_SSL=TRUE )
 


### PR DESCRIPTION
This is a set of fixes to the build system that improve portability, especially when packaging `restbed` in Linux distributions.

This is basically a rebased version of #294 + other related fixes (including one from @aberaud ).