### PR TITLE
introduced windows dll export macros

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,11 @@ endif ( )
 
 include_directories( ${INCLUDE_DIR} SYSTEM ${asio_INCLUDE} ${ssl_INCLUDE} )
 
+if ( WIN32 )
+	add_definitions( -DWIN_DLL_EXPORT )
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4251")
+endif ( )
+
 #
 # Build
 #

--- a/source/corvusoft/restbed/context_placeholder.hpp
+++ b/source/corvusoft/restbed/context_placeholder.hpp
@@ -12,6 +12,17 @@
 
 //External Includes
 
+//Windows DLL Exports
+#if defined(_WIN32) || defined(__WIN32__) || defined(WIN32) || defined(_WIN64)
+	#ifdef WIN_DLL_EXPORT
+		#define CONTEXT_PLACEHOLDER_EXPORT __declspec(dllexport)
+	#else
+		#define CONTEXT_PLACEHOLDER_EXPORT __declspec(dllimport)
+	#endif
+#else
+	#define CONTEXT_PLACEHOLDER_EXPORT
+#endif
+
 //System Namespaces
 
 //Project Namespaces
@@ -23,7 +34,7 @@ namespace restbed
     //Forward Declarations
     
     template< typename Type  >
-    class ContextPlaceholder : public ContextPlaceholderBase
+    class CONTEXT_PLACEHOLDER_EXPORT ContextPlaceholder : public ContextPlaceholderBase
     {
         public:
             //Friends

--- a/source/corvusoft/restbed/context_placeholder_base.hpp
+++ b/source/corvusoft/restbed/context_placeholder_base.hpp
@@ -11,6 +11,17 @@
 
 //External Includes
 
+//Windows DLL Exports
+#if defined(_WIN32) || defined(__WIN32__) || defined(WIN32) || defined(_WIN64)
+	#ifdef WIN_DLL_EXPORT
+		#define CONTEXT_PLACEHOLDER_BASE_EXPORT __declspec(dllexport)
+	#else
+		#define CONTEXT_PLACEHOLDER_BASE_EXPORT __declspec(dllimport)
+	#endif
+#else
+	#define CONTEXT_PLACEHOLDER_BASE_EXPORT
+#endif
+
 //System Namespaces
 
 //Project Namespaces
@@ -21,7 +32,7 @@ namespace restbed
 {
     //Forward Declarations
     
-    class ContextPlaceholderBase
+    class CONTEXT_PLACEHOLDER_BASE_EXPORT ContextPlaceholderBase
     {
         public:
             //Friends

--- a/source/corvusoft/restbed/context_value.hpp
+++ b/source/corvusoft/restbed/context_value.hpp
@@ -16,6 +16,17 @@
 
 //External Includes
 
+//Windows DLL Exports
+#if defined(_WIN32) || defined(__WIN32__) || defined(WIN32) || defined(_WIN64)
+	#ifdef WIN_DLL_EXPORT
+		#define CONTEXT_VALUE_EXPORT __declspec(dllexport)
+	#else
+		#define CONTEXT_VALUE_EXPORT __declspec(dllimport)
+	#endif
+#else
+	#define CONTEXT_VALUE_EXPORT
+#endif
+
 //System Namespaces
 
 //Project Namespaces
@@ -26,7 +37,7 @@ namespace restbed
 {
     //Forward Declarations
     
-    class ContextValue
+    class CONTEXT_VALUE_EXPORT ContextValue
     {
         public:
             //Friends

--- a/source/corvusoft/restbed/http.hpp
+++ b/source/corvusoft/restbed/http.hpp
@@ -16,6 +16,17 @@
 
 //External Includes
 
+//Windows DLL Exports
+#if defined(_WIN32) || defined(__WIN32__) || defined(WIN32) || defined(_WIN64)
+	#ifdef WIN_DLL_EXPORT
+		#define HTTP_EXPORT __declspec(dllexport)
+	#else
+		#define HTTP_EXPORT __declspec(dllimport)
+	#endif
+#else
+	#define HTTP_EXPORT
+#endif
+
 //System Namespaces
 
 //Project Namespaces
@@ -29,7 +40,7 @@ namespace restbed
     class Response;
     class Settings;
     
-    class [[deprecated("HTTP client is deprecated; we will release a complimentary client framework at a future date.")]] Http
+    class [[deprecated("HTTP client is deprecated; we will release a complimentary client framework at a future date.")]] HTTP_EXPORT Http
     {
         public:
             //Friends

--- a/source/corvusoft/restbed/logger.hpp
+++ b/source/corvusoft/restbed/logger.hpp
@@ -16,6 +16,17 @@
 
 //External Includes
 
+//Windows DLL Exports
+#if defined(_WIN32) || defined(__WIN32__) || defined(WIN32) || defined(_WIN64)
+	#ifdef WIN_DLL_EXPORT
+		#define LOGGER_EXPORT __declspec(dllexport)
+	#else
+		#define LOGGER_EXPORT __declspec(dllimport)
+	#endif
+#else
+	#define LOGGER_EXPORT
+#endif
+
 //System Namespaces
 
 //Project Namespaces
@@ -27,7 +38,7 @@ namespace restbed
     //Forward Declarations
     class Settings;
     
-    class Logger
+    class LOGGER_EXPORT Logger
     {
         public:
             //Friends

--- a/source/corvusoft/restbed/request.hpp
+++ b/source/corvusoft/restbed/request.hpp
@@ -20,6 +20,17 @@
 
 //External Includes
 
+//Windows DLL Exports
+#if defined(_WIN32) || defined(__WIN32__) || defined(WIN32) || defined(_WIN64)
+	#ifdef WIN_DLL_EXPORT
+		#define REQUEST_EXPORT __declspec(dllexport)
+	#else
+		#define REQUEST_EXPORT __declspec(dllimport)
+	#endif
+#else
+	#define REQUEST_EXPORT
+#endif
+
 //System Namespaces
 
 //Project Namespaces
@@ -43,7 +54,7 @@ namespace restbed
         class WebSocketManagerImpl;
     }
     
-    class Request
+    class REQUEST_EXPORT Request
     {
         public:
             //Friends

--- a/source/corvusoft/restbed/resource.hpp
+++ b/source/corvusoft/restbed/resource.hpp
@@ -14,6 +14,17 @@
 
 //External Includes
 
+//Windows DLL Exports
+#if defined(_WIN32) || defined(__WIN32__) || defined(WIN32) || defined(_WIN64)
+	#ifdef WIN_DLL_EXPORT
+		#define RESOURCE_EXPORT __declspec(dllexport)
+	#else
+		#define RESOURCE_EXPORT __declspec(dllimport)
+	#endif
+#else
+	#define RESOURCE_EXPORT
+#endif
+
 //System Namespaces
 
 //Project Namespaces
@@ -34,7 +45,7 @@ namespace restbed
         struct ResourceImpl;
     }
     
-    class Resource
+    class RESOURCE_EXPORT Resource
     {
         public:
             //Friends

--- a/source/corvusoft/restbed/response.hpp
+++ b/source/corvusoft/restbed/response.hpp
@@ -18,6 +18,17 @@
 
 //External Includes
 
+//Windows DLL Exports
+#if defined(_WIN32) || defined(__WIN32__) || defined(WIN32) || defined(_WIN64)
+	#ifdef WIN_DLL_EXPORT
+		#define RESPONSE_EXPORT __declspec(dllexport)
+	#else
+		#define RESPONSE_EXPORT __declspec(dllimport)
+	#endif
+#else
+	#define RESPONSE_EXPORT
+#endif
+
 //System Namespaces
 
 //Project Namespaces
@@ -34,7 +45,7 @@ namespace restbed
         struct ResponseImpl;
     }
     
-    class Response
+    class RESPONSE_EXPORT Response
     {
         public:
             //Friends

--- a/source/corvusoft/restbed/rule.hpp
+++ b/source/corvusoft/restbed/rule.hpp
@@ -12,6 +12,17 @@
 
 //External Includes
 
+//Windows DLL Exports
+#if defined(_WIN32) || defined(__WIN32__) || defined(WIN32) || defined(_WIN64)
+	#ifdef WIN_DLL_EXPORT
+		#define RULE_EXPORT __declspec(dllexport)
+	#else
+		#define RULE_EXPORT __declspec(dllimport)
+	#endif
+#else
+	#define RULE_EXPORT
+#endif
+
 //System Namespaces
 
 //Project Namespaces
@@ -28,7 +39,7 @@ namespace restbed
         struct RuleImpl;
     }
     
-    class Rule
+    class RULE_EXPORT Rule
     {
         public:
             //Friends

--- a/source/corvusoft/restbed/service.hpp
+++ b/source/corvusoft/restbed/service.hpp
@@ -16,6 +16,17 @@
 
 //External Includes
 
+//Windows DLL Exports
+#if defined(_WIN32) || defined(__WIN32__) || defined(WIN32) || defined(_WIN64)
+	#ifdef WIN_DLL_EXPORT
+		#define SERVICE_EXPORT __declspec(dllexport)
+	#else
+		#define SERVICE_EXPORT __declspec(dllimport)
+	#endif
+#else
+	#define SERVICE_EXPORT
+#endif
+
 //System Namespaces
 
 //Project Namespaces
@@ -38,7 +49,7 @@ namespace restbed
         class ServiceImpl;
     }
     
-    class Service
+    class SERVICE_EXPORT Service
     {
         public:
             //Friends

--- a/source/corvusoft/restbed/session.hpp
+++ b/source/corvusoft/restbed/session.hpp
@@ -19,6 +19,17 @@
 
 //External Includes
 
+//Windows DLL Exports
+#if defined(_WIN32) || defined(__WIN32__) || defined(WIN32) || defined(_WIN64)
+	#ifdef WIN_DLL_EXPORT
+		#define SESSION_EXPORT __declspec(dllexport)
+	#else
+		#define SESSION_EXPORT __declspec(dllimport)
+	#endif
+#else
+	#define SESSION_EXPORT
+#endif
+
 //System Namespaces
 
 //Project Namespaces
@@ -41,7 +52,7 @@ namespace restbed
         class WebSocketManagerImpl;
     }
     
-    class Session : public std::enable_shared_from_this< Session >
+    class SESSION_EXPORT Session : public std::enable_shared_from_this< Session >
     {
         public:
             //Friends

--- a/source/corvusoft/restbed/session_manager.hpp
+++ b/source/corvusoft/restbed/session_manager.hpp
@@ -12,6 +12,17 @@
 
 //External Includes
 
+//Windows DLL Exports
+#if defined(_WIN32) || defined(__WIN32__) || defined(WIN32) || defined(_WIN64)
+	#ifdef WIN_DLL_EXPORT
+		#define SESSION_MANAGER_EXPORT __declspec(dllexport)
+	#else
+		#define SESSION_MANAGER_EXPORT __declspec(dllimport)
+	#endif
+#else
+	#define SESSION_MANAGER_EXPORT
+#endif
+
 //System Namespaces
 
 //Project Namespaces
@@ -29,7 +40,7 @@ namespace restbed
         struct SessionManagerImpl;
     }
     
-    class SessionManager
+    class SESSION_MANAGER_EXPORT SessionManager
     {
         public:
             //Friends

--- a/source/corvusoft/restbed/settings.hpp
+++ b/source/corvusoft/restbed/settings.hpp
@@ -15,6 +15,17 @@
 
 //External Includes
 
+//Windows DLL Exports
+#if defined(_WIN32) || defined(__WIN32__) || defined(WIN32) || defined(_WIN64)
+	#ifdef WIN_DLL_EXPORT
+		#define SETTINGS_EXPORT __declspec(dllexport)
+	#else
+		#define SETTINGS_EXPORT __declspec(dllimport)
+	#endif
+#else
+	#define SETTINGS_EXPORT
+#endif
+
 //System Namespaces
 
 //Project Namespaces
@@ -31,7 +42,7 @@ namespace restbed
         struct SettingsImpl;
     }
     
-    class Settings
+    class SETTINGS_EXPORT Settings
     {
         public:
             //Friends

--- a/source/corvusoft/restbed/ssl_settings.hpp
+++ b/source/corvusoft/restbed/ssl_settings.hpp
@@ -13,6 +13,17 @@
 
 //External Includes
 
+//Windows DLL Exports
+#if defined(_WIN32) || defined(__WIN32__) || defined(WIN32) || defined(_WIN64)
+	#ifdef WIN_DLL_EXPORT
+		#define SSL_SETTINGS_EXPORT __declspec(dllexport)
+	#else
+		#define SSL_SETTINGS_EXPORT __declspec(dllimport)
+	#endif
+#else
+	#define SSL_SETTINGS_EXPORT
+#endif
+
 //System Namespaces
 
 //Project Namespaces
@@ -29,7 +40,7 @@ namespace restbed
         struct SSLSettingsImpl;
     }
     
-    class SSLSettings
+    class SSL_SETTINGS_EXPORT SSLSettings
     {
         public:
             //Friends

--- a/source/corvusoft/restbed/string.hpp
+++ b/source/corvusoft/restbed/string.hpp
@@ -15,6 +15,17 @@
 
 //External Includes
 
+//Windows DLL Exports
+#if defined(_WIN32) || defined(__WIN32__) || defined(WIN32) || defined(_WIN64)
+	#ifdef WIN_DLL_EXPORT
+		#define STRING_EXPORT __declspec(dllexport)
+	#else
+		#define STRING_EXPORT __declspec(dllimport)
+	#endif
+#else
+	#define STRING_EXPORT
+#endif
+
 //System Namespaces
 
 //Project Namespaces
@@ -25,7 +36,7 @@ namespace restbed
 {
     //Forward Declarations
     
-    class String
+    class STRING_EXPORT String
     {
         public:
             //Friends

--- a/source/corvusoft/restbed/uri.hpp
+++ b/source/corvusoft/restbed/uri.hpp
@@ -15,6 +15,17 @@
 
 //External Includes
 
+//Windows DLL Exports
+#if defined(_WIN32) || defined(__WIN32__) || defined(WIN32) || defined(_WIN64)
+	#ifdef WIN_DLL_EXPORT
+		#define URI_EXPORT __declspec(dllexport)
+	#else
+		#define URI_EXPORT __declspec(dllimport)
+	#endif
+#else
+	#define URI_EXPORT
+#endif
+
 //System Namespaces
 
 //Project Namespaces
@@ -26,10 +37,10 @@ namespace restbed
     //Forward Declarations
     namespace detail
     {
-        struct UriImpl;
+		struct UriImpl;
     }
     
-    class Uri
+    class URI_EXPORT Uri
     {
         public:
             //Friends

--- a/source/corvusoft/restbed/web_socket.hpp
+++ b/source/corvusoft/restbed/web_socket.hpp
@@ -15,6 +15,17 @@
 
 //External Includes
 
+//Windows DLL Exports
+#if defined(_WIN32) || defined(__WIN32__) || defined(WIN32) || defined(_WIN64)
+	#ifdef WIN_DLL_EXPORT
+		#define WEB_SOCKET_EXPORT __declspec(dllexport)
+	#else
+		#define WEB_SOCKET_EXPORT __declspec(dllimport)
+	#endif
+#else
+	#define WEB_SOCKET_EXPORT
+#endif
+
 //System Namespaces
 
 //Project Namespaces
@@ -34,7 +45,7 @@ namespace restbed
         class WebSocketManagerImpl;
     }
     
-    class WebSocket : public std::enable_shared_from_this< WebSocket >
+    class WEB_SOCKET_EXPORT WebSocket : public std::enable_shared_from_this< WebSocket >
     {
         public:
             //Friends

--- a/source/corvusoft/restbed/web_socket_message.hpp
+++ b/source/corvusoft/restbed/web_socket_message.hpp
@@ -16,6 +16,17 @@
 
 //External Includes
 
+//Windows DLL Exports
+#if defined(_WIN32) || defined(__WIN32__) || defined(WIN32) || defined(_WIN64)
+	#ifdef WIN_DLL_EXPORT
+		#define WEB_SOCKET_MESSAGE_EXPORT __declspec(dllexport)
+	#else
+		#define WEB_SOCKET_MESSAGE_EXPORT __declspec(dllimport)
+	#endif
+#else
+	#define WEB_SOCKET_MESSAGE_EXPORT
+#endif
+
 //System Namespaces
 
 //Project Namespaces
@@ -31,7 +42,7 @@ namespace restbed
         struct WebSocketMessageImpl;
     }
     
-    class WebSocketMessage
+    class WEB_SOCKET_MESSAGE_EXPORT WebSocketMessage
     {
         public:
             //Friends


### PR DESCRIPTION
-added cmake options for windows dll exports
-added __declspec(dllexport) and __declspec(dllimport) macros to relevant interfaces
-disabled warning C4251 for windows builds (see https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4251?view=vs-2019)