### PR TITLE
Fix an inferable null pointer dereference on a smart pointer

### DIFF
--- a/source/corvusoft/restbed/http.cpp
+++ b/source/corvusoft/restbed/http.cpp
@@ -162,7 +162,7 @@ namespace restbed
         {
             request->m_pimpl->m_socket->connect( request->get_host( ), request->get_port( ), bind( HttpImpl::request_handler, _1, request, completion_handler ) );
         }
-        else
+        else if ( request->m_pimpl->m_socket not_eq nullptr )
         {
             request->m_pimpl->m_socket->start_write( Http::to_bytes( request ), bind( HttpImpl::write_handler, _1, _2, request, completion_handler ) );
         }


### PR DESCRIPTION
The problem is reported by my static analyzer on smart pointers.

It can be inferred that, in the code snippet presented below, if pointer `A` is a nullptr, the condition will be evaluated to false and take the else branch, which will trigger a null pointer dereference in the else branch. In this patch, the `A` pointer is `request->m_pimpl->m_socket`, which is checked on line 161 (the branch condition) and dereferenced on line 167 (the else branch, which is a nullptr).

```cpp
if (A && A->xxx())
  A->xxx();
else
  A->xxx();
```

In this patch, I added an additional check on the pointer `A` in the else branch.

```cpp
if (A && A->xxx())
  A->xxx();
else if (A)  // <- Check A again before dereference.
  A->xxx();
```