### PR TITLE
Revert "Add vcpkg installation instructions"

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,20 +133,6 @@ Windows Build Instructions
 
 For Microsoft Visual Studio instructions please see feature [#17](https://github.com/Corvusoft/restbed/issues/17).
 
-Building restbed - Using vcpkg
-------------------------------
-
-You can download and install restbed using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
-
-    git clone https://github.com/Microsoft/vcpkg.git
-    cd vcpkg
-    ./bootstrap-vcpkg.sh
-    ./vcpkg integrate install
-    ./vcpkg install restbed
-
-The restbed port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
-
-
 Documentation
 -------------
 


### PR DESCRIPTION
Reverts Corvusoft/restbed#413

This change has caused failures on Linux distros.