### PR TITLE
Revert "Added cmake targets in cmake file so that restbed can be used from another cmake project"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,16 +107,6 @@ if ( BUILD_TESTS )
     add_subdirectory( "${PROJECT_SOURCE_DIR}/test/integration" )
 endif ( )
 
-if ( BUILD_STATIC )
-    set(CMAKE_INSTALL_INCLUDEDIR "include")
-
-    target_include_directories(${STATIC_LIBRARY_NAME}
-        PUBLIC
-        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
-        )
-endif()
-
-
 #
 # Install
 #
@@ -124,41 +114,5 @@ file( GLOB ARTIFACTS "${SOURCE_DIR}/*.hpp" )
 
 install( FILES "${INCLUDE_DIR}/${PROJECT_NAME}" DESTINATION "${CMAKE_INSTALL_PREFIX}/include" )
 install( FILES ${ARTIFACTS} DESTINATION "${CMAKE_INSTALL_PREFIX}/include/corvusoft/${PROJECT_NAME}" )
-
-install( TARGETS ${STATIC_LIBRARY_NAME} 
-         EXPORT restbedTargets 
-         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} 
-         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} 
-         COMPONENT library )
-
-set(INSTALL_CONFIGDIR "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
-
-install(EXPORT restbedTargets
-        FILE restbedTargets.cmake
-        NAMESPACE restbed::
-        DESTINATION ${INSTALL_CONFIGDIR}
-        )
-
-include(CMakePackageConfigHelpers)
-write_basic_package_version_file(
-        ${CMAKE_CURRENT_BINARY_DIR}/restbedConfigVersion.cmake
-        VERSION ${PROJECT_VERSION}
-        COMPATIBILITY AnyNewerVersion
-)
-
-configure_package_config_file(
-        ${CMAKE_CURRENT_LIST_DIR}/cmake/restbedConfig.cmake.in
-        ${CMAKE_CURRENT_BINARY_DIR}/restbedConfig.cmake
-        INSTALL_DESTINATION ${INSTALL_CONFIGDIR}
-)
-
-## Install all the helper files
-install(
-        FILES
-        ${CMAKE_CURRENT_BINARY_DIR}/restbedConfig.cmake
-        ${CMAKE_CURRENT_BINARY_DIR}/restbedConfigVersion.cmake
-        DESTINATION ${INSTALL_CONFIGDIR}
-)
-
 install( TARGETS ${STATIC_LIBRARY_NAME} LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT library )
 install( TARGETS ${SHARED_LIBRARY_NAME} LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT library )

--- a/cmake/RestbedConfig.cmake.in
+++ b/cmake/RestbedConfig.cmake.in
@@ -1,3 +1,0 @@
-@PACKAGE_INIT@
-
-include(${CMAKE_CURRENT_LIST_DIR}/restbedTargets.cmake)


### PR DESCRIPTION
Reverts Corvusoft/restbed#447 as it caused failure on linux systems.

```
-- Detecting C compile features

-- Detecting C compile features - done

CMake Error: File /home/travis/build/Corvusoft/restbed/cmake/restbedConfig.cmake.in does not exist.

CMake Error at /usr/local/cmake-3.9.2/share/cmake-3.9/Modules/CMakePackageConfigHelpers.cmake:312 (configure_file):

  configure_file Problem configuring file

Call Stack (most recent call first):

  CMakeLists.txt:149 (configure_package_config_file)

-- Configuring incomplete, errors occurred!

See also "/home/travis/build/Corvusoft/restbed/build/CMakeFiles/CMakeOutput.log".```
