### PR TITLE
Fix memory leak (session not freed)

### DIFF
--- a/source/corvusoft/restbed/detail/socket_impl.cpp
+++ b/source/corvusoft/restbed/detail/socket_impl.cpp
@@ -388,6 +388,13 @@ namespace restbed
             
 #endif
 			}
+			else
+			{
+				while(!m_pending_writes.empty())
+				{
+					m_pending_writes.pop();
+				}
+			}
         }
 
         void SocketImpl::write( const Bytes& data, const function< void ( const error_code&, size_t ) >& callback )


### PR DESCRIPTION
If pending writes are present at the moment a socket is closed, these
pending writes are not freed. These writes hold callbacks with shared
pointers. One of these is a shared pointers to the session object.
Therefore the session object can't be freed. The socket itself cant be
freed because the session has a shared pointer to the socket.

It seams that there is another memleak on high load. The session object seams to be hold at another place, or that my fix misses something.