### PR TITLE
Build for ARM platforms fixed

### DIFF
--- a/source/corvusoft/restbed/uri.cpp
+++ b/source/corvusoft/restbed/uri.cpp
@@ -100,7 +100,7 @@ namespace restbed
     
     string Uri::decode( const string& value )
     {
-        static const char hex_to_dec[256] = 
+        static const signed char hex_to_dec[256] =
         {
             /*       0  1  2  3   4  5  6  7   8  9  A  B   C  D  E  F */
             /* 0 */ -1,-1,-1,-1, -1,-1,-1,-1, -1,-1,-1,-1, -1,-1,-1,-1,
@@ -133,8 +133,8 @@ namespace restbed
         string result;
         result.reserve( valuesize );
 
-        char c1 = 0;
-        char c2 = 0;
+        signed char c1 = 0;
+        signed char c2 = 0;
         unsigned char cindex = 0;
         
         string::size_type index = 0;
@@ -149,7 +149,7 @@ namespace restbed
                 c2 = hex_to_dec[ cindex ];
                 if ( c1 != -1 && c2 != -1 )
                 {
-                    result.push_back( ( c1 << 4 ) + c2 );
+                    result.push_back( (char)(( c1 << 4 ) + c2) );
                     index += 2;
                     continue;
                 }


### PR DESCRIPTION
The cross-platform gcc for ARM usually uses 'unsigned char' as default for 'char'.
See also: https://developer.arm.com/documentation/den0013/d/Porting/Miscellaneous-C-porting-issues/unsigned-char-and-signed-char

Since hex_to_dec[] (declared in Uri::decode()) uses -1 as potential value it has to be declared explicitly as 'signed char' instead of 'char' to make it compile for ARM platforms.
hex_to_dec[] was introduced in commit c99646c154a710330dfa99cc59d8899316095a8b "Fix and optimize URI codec.https://github.com/Corvusoft/restbed/issues/442".
Previous versions of restbed used to compile fine for ARM platforms.