### PR TITLE
cmake/Findasio.cmake and cmake/Findcatch.cmake adapted for usage with…

### DIFF
--- a/cmake/Findasio.cmake
+++ b/cmake/Findasio.cmake
@@ -1,4 +1,13 @@
-find_path( asio_INCLUDE asio.hpp HINTS "${PROJECT_SOURCE_DIR}/dependency/asio/asio/include" "/usr/include" "/usr/local/include" "/opt/local/include" )
+find_path( asio_INCLUDE asio.hpp HINTS "/usr/include" "/usr/local/include" "/opt/local/include" )
+
+# If the asio library was not found, we try to use the Git subnodule dependency/asio instead.
+# Note that "${PROJECT_SOURCE_DIR}/..." does not always work as find_path() hint because these paths are
+# relative to the sysroot of the toolchain which could differ from / when using CMake toolchain files.
+# Therefore we have to check the existence of the Git submodule with EXISTS which accepts absolute paths.
+# See also: https://cmake.org/cmake/help/latest/variable/CMAKE_SYSROOT.html
+if ( NOT asio_INCLUDE AND EXISTS "${PROJECT_SOURCE_DIR}/dependency/asio/asio/include/asio.hpp" )
+    set( asio_INCLUDE "${PROJECT_SOURCE_DIR}/dependency/asio/asio/include" )
+endif ( )
 
 if ( asio_INCLUDE )
     set( ASIO_FOUND TRUE )

--- a/cmake/Findcatch.cmake
+++ b/cmake/Findcatch.cmake
@@ -1,4 +1,13 @@
-find_path( catch_INCLUDE catch.hpp HINTS "${PROJECT_SOURCE_DIR}/dependency/catch/single_include/catch2" "/usr/include/catch2/single_include" "/usr/include/catch2" "/usr/local/include/catch2/single_include" "/usr/local/include/catch2" "/opt/local/include/catch2/single_include" "/opt/local/include/catch2" )
+find_path( catch_INCLUDE catch.hpp HINTS "/usr/include/catch2/single_include" "/usr/include/catch2" "/usr/local/include/catch2/single_include" "/usr/local/include/catch2" "/opt/local/include/catch2/single_include" "/opt/local/include/catch2" )
+
+# If the catch library was not found, we try to use the Git subnodule dependency/catch instead.
+# Note that "${PROJECT_SOURCE_DIR}/..." does not always work as find_path() hint because these paths are
+# relative to the sysroot of the toolchain which could differ from / when using CMake toolchain files.
+# Therefore we have to check the existence of the Git submodule with EXISTS which accepts absolute paths.
+# See also: https://cmake.org/cmake/help/latest/variable/CMAKE_SYSROOT.html
+if ( NOT catch_INCLUDE AND EXISTS "${PROJECT_SOURCE_DIR}/dependency/catch/single_include/catch2/catch.hpp" )
+    set( catch_INCLUDE "${PROJECT_SOURCE_DIR}/dependency/catch/single_include/catch2" )
+endif ( )
 
 include(FindPackageHandleStandardArgs)
 FIND_PACKAGE_HANDLE_STANDARD_ARGS(catch DEFAULT_MSG catch_INCLUDE)


### PR DESCRIPTION
… cross-compiling CMake toolchain files

Both files have been modified so they are able to find the git submodules 'dependency/asio' resp. 'dependency/catch' even if a CMake toolchain file was used with a different CMAKE_SYSROOT than / (which is common for cross-compiling CMake toolchain files).

See also: https://cmake.org/cmake/help/latest/variable/CMAKE_SYSROOT.html
