### PR TITLE
Enable build with -fvisibility=hidden

### DIFF
--- a/source/corvusoft/restbed/context_placeholder.hpp
+++ b/source/corvusoft/restbed/context_placeholder.hpp
@@ -20,7 +20,7 @@
 		#define CONTEXT_PLACEHOLDER_EXPORT __declspec(dllimport)
 	#endif
 #else
-	#define CONTEXT_PLACEHOLDER_EXPORT
+	#define CONTEXT_PLACEHOLDER_EXPORT __attribute__((visibility ("default")))
 #endif
 
 //System Namespaces

--- a/source/corvusoft/restbed/context_placeholder_base.hpp
+++ b/source/corvusoft/restbed/context_placeholder_base.hpp
@@ -19,7 +19,7 @@
 		#define CONTEXT_PLACEHOLDER_BASE_EXPORT __declspec(dllimport)
 	#endif
 #else
-	#define CONTEXT_PLACEHOLDER_BASE_EXPORT
+	#define CONTEXT_PLACEHOLDER_BASE_EXPORT __attribute__((visibility ("default")))
 #endif
 
 //System Namespaces

--- a/source/corvusoft/restbed/context_value.hpp
+++ b/source/corvusoft/restbed/context_value.hpp
@@ -24,7 +24,7 @@
 		#define CONTEXT_VALUE_EXPORT __declspec(dllimport)
 	#endif
 #else
-	#define CONTEXT_VALUE_EXPORT
+	#define CONTEXT_VALUE_EXPORT __attribute__((visibility ("default")))
 #endif
 
 //System Namespaces

--- a/source/corvusoft/restbed/http.hpp
+++ b/source/corvusoft/restbed/http.hpp
@@ -24,7 +24,7 @@
 		#define HTTP_EXPORT __declspec(dllimport)
 	#endif
 #else
-	#define HTTP_EXPORT
+	#define HTTP_EXPORT __attribute__((visibility ("default")))
 #endif
 
 //System Namespaces

--- a/source/corvusoft/restbed/http.hpp
+++ b/source/corvusoft/restbed/http.hpp
@@ -23,8 +23,11 @@
 	#else
 		#define HTTP_EXPORT __declspec(dllimport)
 	#endif
+	#define DEPRECATED(MSG) __declspec(deprecated(MSG))
 #else
+    // gcc11 and clang12 don't like mixing __attribute__ and [[deprecated(MSG)]]
 	#define HTTP_EXPORT __attribute__((visibility ("default")))
+	#define DEPRECATED(MSG) __attribute__((__deprecated__(MSG)))
 #endif
 
 //System Namespaces
@@ -39,8 +42,8 @@ namespace restbed
     class Request;
     class Response;
     class Settings;
-    
-    class [[deprecated("HTTP client is deprecated; we will release a complimentary client framework at a future date.")]] HTTP_EXPORT Http
+
+    class DEPRECATED("HTTP client is deprecated; we will release a complimentary client framework at a future date.") HTTP_EXPORT Http
     {
         public:
             //Friends

--- a/source/corvusoft/restbed/logger.hpp
+++ b/source/corvusoft/restbed/logger.hpp
@@ -24,7 +24,7 @@
 		#define LOGGER_EXPORT __declspec(dllimport)
 	#endif
 #else
-	#define LOGGER_EXPORT
+	#define LOGGER_EXPORT __attribute__((visibility ("default")))
 #endif
 
 //System Namespaces

--- a/source/corvusoft/restbed/request.hpp
+++ b/source/corvusoft/restbed/request.hpp
@@ -28,7 +28,7 @@
 		#define REQUEST_EXPORT __declspec(dllimport)
 	#endif
 #else
-	#define REQUEST_EXPORT
+	#define REQUEST_EXPORT __attribute__((visibility ("default")))
 #endif
 
 //System Namespaces

--- a/source/corvusoft/restbed/resource.hpp
+++ b/source/corvusoft/restbed/resource.hpp
@@ -22,7 +22,7 @@
 		#define RESOURCE_EXPORT __declspec(dllimport)
 	#endif
 #else
-	#define RESOURCE_EXPORT
+	#define RESOURCE_EXPORT __attribute__((visibility ("default")))
 #endif
 
 //System Namespaces

--- a/source/corvusoft/restbed/response.hpp
+++ b/source/corvusoft/restbed/response.hpp
@@ -26,7 +26,7 @@
 		#define RESPONSE_EXPORT __declspec(dllimport)
 	#endif
 #else
-	#define RESPONSE_EXPORT
+	#define RESPONSE_EXPORT __attribute__((visibility ("default")))
 #endif
 
 //System Namespaces

--- a/source/corvusoft/restbed/rule.hpp
+++ b/source/corvusoft/restbed/rule.hpp
@@ -20,7 +20,7 @@
 		#define RULE_EXPORT __declspec(dllimport)
 	#endif
 #else
-	#define RULE_EXPORT
+	#define RULE_EXPORT __attribute__((visibility ("default")))
 #endif
 
 //System Namespaces

--- a/source/corvusoft/restbed/service.hpp
+++ b/source/corvusoft/restbed/service.hpp
@@ -24,7 +24,7 @@
 		#define SERVICE_EXPORT __declspec(dllimport)
 	#endif
 #else
-	#define SERVICE_EXPORT
+	#define SERVICE_EXPORT __attribute__((visibility ("default")))
 #endif
 
 //System Namespaces

--- a/source/corvusoft/restbed/session.hpp
+++ b/source/corvusoft/restbed/session.hpp
@@ -27,7 +27,7 @@
 		#define SESSION_EXPORT __declspec(dllimport)
 	#endif
 #else
-	#define SESSION_EXPORT
+	#define SESSION_EXPORT __attribute__((visibility ("default")))
 #endif
 
 //System Namespaces

--- a/source/corvusoft/restbed/session_manager.hpp
+++ b/source/corvusoft/restbed/session_manager.hpp
@@ -20,7 +20,7 @@
 		#define SESSION_MANAGER_EXPORT __declspec(dllimport)
 	#endif
 #else
-	#define SESSION_MANAGER_EXPORT
+	#define SESSION_MANAGER_EXPORT __attribute__((visibility ("default")))
 #endif
 
 //System Namespaces

--- a/source/corvusoft/restbed/settings.hpp
+++ b/source/corvusoft/restbed/settings.hpp
@@ -23,7 +23,7 @@
 		#define SETTINGS_EXPORT __declspec(dllimport)
 	#endif
 #else
-	#define SETTINGS_EXPORT
+	#define SETTINGS_EXPORT __attribute__((visibility ("default")))
 #endif
 
 //System Namespaces

--- a/source/corvusoft/restbed/ssl_settings.hpp
+++ b/source/corvusoft/restbed/ssl_settings.hpp
@@ -21,7 +21,7 @@
 		#define SSL_SETTINGS_EXPORT __declspec(dllimport)
 	#endif
 #else
-	#define SSL_SETTINGS_EXPORT
+	#define SSL_SETTINGS_EXPORT __attribute__((visibility ("default")))
 #endif
 
 //System Namespaces

--- a/source/corvusoft/restbed/string.hpp
+++ b/source/corvusoft/restbed/string.hpp
@@ -23,7 +23,7 @@
 		#define STRING_EXPORT __declspec(dllimport)
 	#endif
 #else
-	#define STRING_EXPORT
+	#define STRING_EXPORT __attribute__((visibility ("default")))
 #endif
 
 //System Namespaces

--- a/source/corvusoft/restbed/uri.hpp
+++ b/source/corvusoft/restbed/uri.hpp
@@ -23,7 +23,7 @@
 		#define URI_EXPORT __declspec(dllimport)
 	#endif
 #else
-	#define URI_EXPORT
+	#define URI_EXPORT __attribute__((visibility ("default")))
 #endif
 
 //System Namespaces

--- a/source/corvusoft/restbed/web_socket.hpp
+++ b/source/corvusoft/restbed/web_socket.hpp
@@ -23,7 +23,7 @@
 		#define WEB_SOCKET_EXPORT __declspec(dllimport)
 	#endif
 #else
-	#define WEB_SOCKET_EXPORT
+	#define WEB_SOCKET_EXPORT __attribute__((visibility ("default")))
 #endif
 
 //System Namespaces

--- a/source/corvusoft/restbed/web_socket_message.hpp
+++ b/source/corvusoft/restbed/web_socket_message.hpp
@@ -24,7 +24,7 @@
 		#define WEB_SOCKET_MESSAGE_EXPORT __declspec(dllimport)
 	#endif
 #else
-	#define WEB_SOCKET_MESSAGE_EXPORT
+	#define WEB_SOCKET_MESSAGE_EXPORT __attribute__((visibility ("default")))
 #endif
 
 //System Namespaces


### PR DESCRIPTION
I tried to build and run a program with `-fsanitize=cfi` (and `-flto=thin -fvisibility=hidden -fno-sanitize-trap=cfi`) according to the [clang documentation](https://clang.llvm.org/docs/ControlFlowIntegrity.html).

So with this option, all class are by default hidden.

According to [GCC documentation](https://gcc.gnu.org/wiki/Visibility), the C++ visibility support should be `__attribute__ ((visibility ("default")))` for `*_EXPORT` with Linux.