### PR TITLE
Service::m_uptime must be thread-safe

### DIFF
--- a/source/corvusoft/restbed/detail/service_impl.hpp
+++ b/source/corvusoft/restbed/detail/service_impl.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 //System Includes
+#include <atomic>
 #include <set>
 #include <map>
 #include <chrono>
@@ -138,7 +139,7 @@ namespace restbed
                 //Operators
                 
                 //Properties
-                std::chrono::steady_clock::time_point m_uptime;
+                std::atomic<std::chrono::steady_clock::time_point> m_uptime;
                 
                 std::shared_ptr< Logger > m_logger;
                 

--- a/source/corvusoft/restbed/service.cpp
+++ b/source/corvusoft/restbed/service.cpp
@@ -88,7 +88,8 @@ namespace restbed
     
     bool Service::is_up( void ) const
     {
-        return m_pimpl->m_uptime not_eq steady_clock::time_point::min( );
+        std::chrono::steady_clock::time_point value = m_pimpl->m_uptime;
+        return value not_eq steady_clock::time_point::min( );
     }
     
     bool Service::is_down( void ) const
@@ -353,7 +354,8 @@ namespace restbed
             return seconds( 0 );
         }
         
-        return duration_cast< seconds >( steady_clock::now( ) - m_pimpl->m_uptime );
+        std::chrono::steady_clock::time_point value = m_pimpl->m_uptime;
+        return duration_cast< seconds >( steady_clock::now( ) - value );
     }
     
     const shared_ptr< const Uri > Service::get_http_uri( void ) const


### PR DESCRIPTION
In service, the field `m_uptime` should be thread-safe.

I started a service in a thread.
In another thread I checked if service `is_up`.

I may have a data race : when service is up, the service write in `m_uptime` and the other thread may read `m_uptime` via `is_up`.

The solution is not perfect. In `get_uptime`, the service could be down between `is_down` and the read of the value but it's better than nothing and avoid the use of mutex.