### PR TITLE
fix: removing unused imports

### DIFF
--- a/documentation/example/RULES_ENGINE.md
+++ b/documentation/example/RULES_ENGINE.md
@@ -9,9 +9,7 @@ Example
 ```C++
 #include <string>
 #include <memory>
-#include <string>
 #include <cstdlib>
-#include <ciso646>
 #include <functional>
 #include <restbed>
 


### PR DESCRIPTION
I noticed that these two imports in docs are not used.
I suggest to get them removed. 