### PR TITLE
add support for QNX 7.1/8.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,7 @@ if( NOT WIN32 )
     set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Weffc++ -pedantic -Wno-unknown-pragmas -Wno-deprecated-declarations -Wno-non-virtual-dtor" )
 endif ( )
 
-if ( UNIX AND NOT APPLE )
+if ( UNIX AND NOT APPLE AND NOT QNX)
     set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread" )
 endif ( )
 

--- a/source/corvusoft/restbed/detail/socket_impl.cpp
+++ b/source/corvusoft/restbed/detail/socket_impl.cpp
@@ -301,7 +301,7 @@ namespace restbed
             setsockopt(socket.native_handle(), SOL_SOCKET, SO_KEEPALIVE, &val, sizeof(uint32_t));
 #ifdef __APPLE__
             setsockopt(socket.native_handle(), IPPROTO_TCP, TCP_KEEPALIVE, &start, sizeof(uint32_t));
-#elif defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__DragonFly__) 
+#elif defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__DragonFly__) || defined(__QNX__)
             setsockopt(socket.native_handle(), IPPROTO_TCP, SO_KEEPALIVE, &start, sizeof(uint32_t));
 #else
             // Linux based systems


### PR DESCRIPTION
**These changes facilitate porting of Restbed for QNX7.1/8.0.** #549 
Build files are available at https://github.com/qnx-ports/build-files/tree/main/ports/restbed

**NOTE**: QNX ports are only supported from a Linux host operating system

## Create a workspace
```bash
mkdir -p ~/qnx_workspace && cd ~/qnx_workspace
git clone https://github.com/qnx-ports/build-files.git
```

## Clone Restbed repository from tested release version
```bash
git clone https://github.com/qnx-ports/restbed.git
```

## Or clone it from original repository
```bash
git clone https://github.com/Corvusoft/restbed.git
```

## Update 3rdParty dependencies
```bash
cd restbed
git submodule update --init --recursive
cd -
```
## Pre-requisite:
* Install Docker on Ubuntu
   - https://docs.docker.com/engine/install/ubuntu/
* Install QNX license and SDP installation (~/.qnx and ~/qnx800 by default) 
   - https://www.qnx.com/products/everywhere/ (**Non-Commercial Use**)

## Setup a Docker container

```bash
# Build the Docker image and create a container
cd build-files/docker
./docker-build-qnx-image.sh
./docker-create-container.sh

# Now you are in the Docker container
```

## Or setup Ubuntu host
```bash
# source qnxsdp-env.sh
source ~/qnx800/qnxsdp-env.sh
```

## Compile the port for QNX
```bash
cd ~/qnx_workspace
# Build Restbed and install it in sysroot (QNX SDP)
make -C build-files/ports/restbed install JLEVEL=$(nproc)
# Or build Restbed and install it in a staging area
make -C build-files/ports/restbed install JLEVEL=$(nproc) INSTALL_ROOT_nto=<PATH_TO_YOUR_STAGING_AREA> USE_INSTALL_ROOT=true
```

## How to run tests

Copy (scp) Restbed tests in to the QNX target.
```bash
cd ~/qnx_workspace
# Build restbed and all tests
make -C build-files/ports/restbed check JLEVEL=$(nproc)

# define target IP address
TARGET_HOST=<target-ip-address-or-hostname>

# remove old test dir on target
ssh qnxuser@$TARGET_HOST "rm -rf restbed_tests"

# create new test dir on target
ssh qnxuser@$TARGET_HOST "mkdir restbed_tests"

# copy restbed build tree to your QNX target
scp -r build-files/ports/restbed/nto-aarch64-le/build/* qnxuser@$TARGET_HOST:/data/home/qnxuser/restbed_tests/
# or
scp -r build-files/ports/restbed/nto-x86_64-o/build/* qnxuser@$TARGET_HOST:/data/home/qnxuser/restbed_tests/
```

Run tests on the target.
```bash
# ssh into the target
ssh qnxuser@$TARGET_HOST
## Run tests
cd /data/home/qnxuser/restbed_tests/
python ./base_testsuite.py
```

## Tips and triks.

With your spd you can create and run virtual x86_64 TARGET of QNX.
```bash
# source qnxsdp-env.sh
source ~/qnx800/qnxsdp-env.sh

# Install on linux host virtual machine like qemu/vxbox/vmware
# Create and run virtual target of QNX
# qemu
mkqnximage --type=qemu --arch=x86_64 --clean --run --force --python=yes --data-size=500 --data-inodes=20000
# or vmware
mkqnximage --type=vmware --arch=x86_64 --clean --run --force --python=yes --data-size=500 --data-inodes=20000
# or virtual box
mkqnximage --type=vbox --arch=x86_64 --clean --run --force --python=yes --data-size=500 --data-inodes=20000
```

**Note**: All tests have to return no error.

```bash
...
======================================================
Tests suites summary for Restbed 4.8
======================================================
# test/unit        - ALL:10 PASS:10 FAIL:0 SKIP:0 [0:00:00.115737]
# test/feature     - ALL:65 PASS:65 FAIL:0 SKIP:0 [0:00:14.513149]
# test/regression  - ALL:31 PASS:31 FAIL:0 SKIP:0 [0:00:08.603444]
# test/integration - ALL:10 PASS:10 FAIL:0 SKIP:0 [0:00:00.114280]
# TOTAL: 116 [0:00:23.346610]
# PASS: 116
# FAIL: 0
# SKIP: 0
======================================================
```
